### PR TITLE
fix: prevent invalid MAC address when dynamic_mac_address=true

### DIFF
--- a/api/hyperv-winrm/vm_network_adapter.go
+++ b/api/hyperv-winrm/vm_network_adapter.go
@@ -48,9 +48,7 @@ if ($vmNetworkAdapter.SwitchName) {
 $SetVmNetworkAdapterArgs = @{}
 $SetVmNetworkAdapterArgs.VmName=$vmNetworkAdapter.VmName
 $SetVmNetworkAdapterArgs.Name=$vmNetworkAdapter.Name
-if ($vmNetworkAdapter.DynamicMacAddress) {
-	$SetVmNetworkAdapterArgs.DynamicMacAddress=$vmNetworkAdapter.DynamicMacAddress
-} elseif ($vmNetworkAdapter.StaticMacAddress) {
+if ($vmNetworkAdapter.StaticMacAddress -and $vmNetworkAdapter.StaticMacAddress -ne '') {
 	$SetVmNetworkAdapterArgs.StaticMacAddress=$vmNetworkAdapter.StaticMacAddress
 }
 $SetVmNetworkAdapterArgs.MacAddressSpoofing=$macAddressSpoofing
@@ -463,9 +461,7 @@ if ($vmNetworkAdaptersObject.Name -ne $vmNetworkAdapter.Name) {
 $SetVmNetworkAdapterArgs = @{}
 $SetVmNetworkAdapterArgs.VmName=$vmNetworkAdapter.VmName
 $SetVmNetworkAdapterArgs.Name=$vmNetworkAdapter.Name
-if ($vmNetworkAdapter.DynamicMacAddress) {
-	$SetVmNetworkAdapterArgs.DynamicMacAddress=$vmNetworkAdapter.DynamicMacAddress
-} elseif ($vmNetworkAdapter.StaticMacAddress) {
+if ($vmNetworkAdapter.StaticMacAddress -and $vmNetworkAdapter.StaticMacAddress -ne '') {
 	$SetVmNetworkAdapterArgs.StaticMacAddress=$vmNetworkAdapter.StaticMacAddress
 }
 


### PR DESCRIPTION
## Summary

- Fix issue where `dynamic_mac_address = true` caused invalid MAC address `00-00-00-00-00-00` error
- Remove `DynamicMacAddress` parameter from PowerShell splatting, letting Hyper-V handle dynamic MAC generation through default behavior
- Only set `StaticMacAddress` when explicitly specified

## Changes

- Modified `createVmNetworkAdapterTemplate` (line 51-54)
- Modified `updateVmNetworkAdapterTemplate` (line 466-469)

## Test plan

- [ ] Create VM with `dynamic_mac_address = true` - should succeed without MAC error
- [ ] Verify Hyper-V Manager shows valid dynamic MAC (00-15-5D-XX-XX-XX format)
- [ ] Create VM with `static_mac_address` specified - should still work correctly

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)