### PR TITLE
fix(ci): update actions/cache to v4 and fix semgrep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@v4
       continue-on-error: true
       id: cache-go-pkg-mod
       timeout-minutes: 3
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@v4
       continue-on-error: true
       id: cache-go-pkg-mod
       timeout-minutes: 3
@@ -88,7 +88,7 @@ jobs:
           ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}-${{ hashFiles('**/go.sum') }}
           ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}
           ${{ runner.os }}-go-pkg-mod
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@v4
       continue-on-error: true
       id: cache-go-build
       timeout-minutes: 3
@@ -102,7 +102,7 @@ jobs:
           ${{ runner.os }}-go-build-${{ hashFiles('.github/workflows/release.yml') }}
           ${{ runner.os }}-go-build
     - name: Cache cache-terraform-plugin-dir
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4
       continue-on-error: true
       id: cache-terraform-plugin-dir
       timeout-minutes: 2
@@ -129,7 +129,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Cache cache-terraform-providers-schema
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4
       continue-on-error: true
       id: cache-terraform-providers-schema
       timeout-minutes: 2
@@ -138,7 +138,7 @@ jobs:
           terraform-providers-schema
         key: ${{ runner.os }}-terraform-providers-schema-${{ hashFiles('.github/workflows/release.yml') }}-${{ hashFiles('**/go.sum') }}-${{ hashFiles('internal/**', 'api/**', 'powershell/**') }}
     - name: Cache cache-terraform-plugin-dir
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4
       continue-on-error: true
       id: cache-terraform-plugin-dir
       timeout-minutes: 2
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@v4
       continue-on-error: true
       id: cache-go-pkg-mod
       timeout-minutes: 3
@@ -186,7 +186,7 @@ jobs:
           ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}-${{ hashFiles('**/go.sum') }}
           ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}
           ${{ runner.os }}-go-pkg-mod
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@v4
       continue-on-error: true
       id: cache-go-build
       timeout-minutes: 3
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4
         continue-on-error: true
         id: cache-go-pkg-mod
         timeout-minutes: 3
@@ -230,7 +230,7 @@ jobs:
             ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}-${{ hashFiles('**/go.sum') }}
             ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}
             ${{ runner.os }}-go-pkg-mod
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4
         continue-on-error: true
         id: cache-go-build
         timeout-minutes: 3
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4
         continue-on-error: true
         id: cache-go-pkg-mod
         timeout-minutes: 3
@@ -269,7 +269,7 @@ jobs:
             ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}-${{ hashFiles('**/go.sum') }}
             ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}
             ${{ runner.os }}-go-pkg-mod
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4
         continue-on-error: true
         id: cache-go-build
         timeout-minutes: 3
@@ -311,13 +311,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # Run the "semgrep ci" command on the command line of the docker image.
-      - run: semgrep ci --no-suppress-errors
-        env:
-          # Connect to Semgrep Cloud Platform through your SEMGREP_APP_TOKEN.
-          # Generate a token from Semgrep Cloud Platform > Settings
-          # and add it to your GitHub secrets.
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      # Run semgrep scan (no Cloud Platform token required)
+      - run: semgrep scan --config auto --error
 
   goreleaser:
     needs: [go_build]
@@ -331,7 +326,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.CREATE_TAG_GITHUB_TOKEN }}
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4
         continue-on-error: true
         id: cache-go-pkg-mod
         timeout-minutes: 3
@@ -343,7 +338,7 @@ jobs:
             ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}-${{ hashFiles('**/go.sum') }}
             ${{ runner.os }}-go-pkg-mod-${{ hashFiles('.github/workflows/release.yml') }}
             ${{ runner.os }}-go-pkg-mod
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4
         continue-on-error: true
         id: cache-go-build
         timeout-minutes: 3


### PR DESCRIPTION
## Summary

- Update `actions/cache` from v4.0.2 to v4 (deprecated version causing CI failures)
- Replace `semgrep ci` with `semgrep scan --config auto` (no SEMGREP_APP_TOKEN required)

## Reason

The previous CI run failed due to:
1. `actions/cache@v4.0.2` is deprecated
2. `semgrep ci` requires `SEMGREP_APP_TOKEN` which is not available in forked repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)