### PR TITLE
fix: HardDisk/DVDドライブのUpdate/Deleteをインデックスベースに統一

### DIFF
--- a/api/hyperv-winrm/vm_dvd_drive.go
+++ b/api/hyperv-winrm/vm_dvd_drive.go
@@ -92,10 +92,9 @@ func (c *ClientConfig) GetVmDvdDrives(ctx context.Context, vmName string) (resul
 }
 
 type updateVmDvdDriveArgs struct {
-	VmName             string
-	ControllerNumber   int
-	ControllerLocation int
-	VmDvdDriveJson     string
+	VmName         string
+	Index          int
+	VmDvdDriveJson string
 }
 
 var updateVmDvdDriveTemplate = template.Must(template.New("UpdateVmDvdDrive").Parse(`
@@ -103,10 +102,10 @@ $ErrorActionPreference = 'Stop'
 Import-Module Hyper-V
 $vmDvdDrive = '{{.VmDvdDriveJson}}' | ConvertFrom-Json
 
-$vmDvdDrivesObject = @(Get-VM -Name '{{.VmName}}*' | ?{$_.Name -eq '{{.VmName}}' } | Get-VMDvdDrive -ControllerLocation {{.ControllerLocation}} -ControllerNumber {{.ControllerNumber}} )
+$vmDvdDrivesObject = @(Get-VM -Name '{{.VmName}}*' | ?{$_.Name -eq '{{.VmName}}' } | Get-VMDvdDrive)[{{.Index}}]
 
 if (!$vmDvdDrivesObject){
-	throw "VM dvd drive does not exist - {{.ControllerLocation}} {{.ControllerNumber}}"
+	throw "VM dvd drive does not exist at index {{.Index}}"
 }
 
 $SetVmDvdDriveArgs = @{}
@@ -136,17 +135,16 @@ Set-VMDvdDrive @SetVmDvdDriveArgs
 func (c *ClientConfig) UpdateVmDvdDrive(
 	ctx context.Context,
 	vmName string,
+	index int,
 	controllerNumber int,
 	controllerLocation int,
-	toControllerNumber int,
-	toControllerLocation int,
 	path string,
 	resourcePoolName string,
 ) (err error) {
 	vmDvdDriveJson, err := json.Marshal(api.VmDvdDrive{
 		VmName:             vmName,
-		ControllerNumber:   toControllerNumber,
-		ControllerLocation: toControllerLocation,
+		ControllerNumber:   controllerNumber,
+		ControllerLocation: controllerLocation,
 		Path:               path,
 		ResourcePoolName:   resourcePoolName,
 	})
@@ -156,32 +154,29 @@ func (c *ClientConfig) UpdateVmDvdDrive(
 	}
 
 	err = c.WinRmClient.RunFireAndForgetScript(ctx, updateVmDvdDriveTemplate, updateVmDvdDriveArgs{
-		VmName:             vmName,
-		ControllerNumber:   controllerNumber,
-		ControllerLocation: controllerLocation,
-		VmDvdDriveJson:     string(vmDvdDriveJson),
+		VmName:         vmName,
+		Index:          index,
+		VmDvdDriveJson: string(vmDvdDriveJson),
 	})
 
 	return err
 }
 
 type deleteVmDvdDriveArgs struct {
-	VmName             string
-	ControllerNumber   int
-	ControllerLocation int
+	VmName string
+	Index  int
 }
 
 var deleteVmDvdDriveTemplate = template.Must(template.New("DeleteVmDvdDrive").Parse(`
 $ErrorActionPreference = 'Stop'
 
-@(Get-VM -Name '{{.VmName}}*' | ?{$_.Name -eq '{{.VmName}}' } | Get-VMDvdDrive -ControllerNumber {{.ControllerNumber}} -ControllerLocation {{.ControllerLocation}}) | Remove-VMDvdDrive
+@(Get-VM -Name '{{.VmName}}*' | ?{$_.Name -eq '{{.VmName}}' } | Get-VMDvdDrive)[{{.Index}}] | Remove-VMDvdDrive
 `))
 
-func (c *ClientConfig) DeleteVmDvdDrive(ctx context.Context, vmName string, controllerNumber int, controllerLocation int) (err error) {
+func (c *ClientConfig) DeleteVmDvdDrive(ctx context.Context, vmName string, index int) (err error) {
 	err = c.WinRmClient.RunFireAndForgetScript(ctx, deleteVmDvdDriveTemplate, deleteVmDvdDriveArgs{
-		VmName:             vmName,
-		ControllerNumber:   controllerNumber,
-		ControllerLocation: controllerLocation,
+		VmName: vmName,
+		Index:  index,
 	})
 
 	return err
@@ -196,9 +191,9 @@ func (c *ClientConfig) CreateOrUpdateVmDvdDrives(ctx context.Context, vmName str
 	currentDvdDrivesLength := len(currentDvdDrives)
 	desiredDvdDrivesLength := len(dvdDrives)
 
+	// 余剰ドライブを末尾から削除（インデックスシフトを回避）
 	for i := currentDvdDrivesLength - 1; i > desiredDvdDrivesLength-1; i-- {
-		currentDvdDrive := currentDvdDrives[i]
-		err = c.DeleteVmDvdDrive(ctx, vmName, currentDvdDrive.ControllerNumber, currentDvdDrive.ControllerLocation)
+		err = c.DeleteVmDvdDrive(ctx, vmName, i)
 		if err != nil {
 			return err
 		}
@@ -208,15 +203,13 @@ func (c *ClientConfig) CreateOrUpdateVmDvdDrives(ctx context.Context, vmName str
 		currentDvdDrivesLength = desiredDvdDrivesLength
 	}
 
-	for i := 0; i <= currentDvdDrivesLength-1; i++ {
-		currentDvdDrive := currentDvdDrives[i]
+	// インデックスベースで既存ドライブを更新
+	for i := 0; i < currentDvdDrivesLength; i++ {
 		dvdDrive := dvdDrives[i]
-
 		err = c.UpdateVmDvdDrive(
 			ctx,
 			vmName,
-			currentDvdDrive.ControllerNumber,
-			currentDvdDrive.ControllerLocation,
+			i,
 			dvdDrive.ControllerNumber,
 			dvdDrive.ControllerLocation,
 			dvdDrive.Path,
@@ -227,7 +220,8 @@ func (c *ClientConfig) CreateOrUpdateVmDvdDrives(ctx context.Context, vmName str
 		}
 	}
 
-	for i := currentDvdDrivesLength - 1 + 1; i <= desiredDvdDrivesLength-1; i++ {
+	// 新規ドライブを作成
+	for i := currentDvdDrivesLength; i < desiredDvdDrivesLength; i++ {
 		dvdDrive := dvdDrives[i]
 		err = c.CreateVmDvdDrive(
 			ctx,
@@ -237,7 +231,6 @@ func (c *ClientConfig) CreateOrUpdateVmDvdDrives(ctx context.Context, vmName str
 			dvdDrive.Path,
 			dvdDrive.ResourcePoolName,
 		)
-
 		if err != nil {
 			return err
 		}

--- a/api/hyperv-winrm/vm_hard_disk_drive.go
+++ b/api/hyperv-winrm/vm_hard_disk_drive.go
@@ -121,8 +121,7 @@ func (c *ClientConfig) GetVmHardDiskDrives(ctx context.Context, vmName string) (
 
 type updateVmHardDiskDriveArgs struct {
 	VmName              string
-	ControllerNumber    int32
-	ControllerLocation  int32
+	Index               int
 	VmHardDiskDriveJson string
 }
 
@@ -131,10 +130,10 @@ $ErrorActionPreference = 'Stop'
 Import-Module Hyper-V
 $vmHardDiskDrive = '{{.VmHardDiskDriveJson}}' | ConvertFrom-Json
 
-$vmHardDiskDrivesObject = @(Get-VM -Name '{{.VmName}}*' | ?{$_.Name -eq '{{.VmName}}' } | Get-VMHardDiskDrive -ControllerLocation {{.ControllerLocation}} -ControllerNumber {{.ControllerNumber}} )
+$vmHardDiskDrivesObject = @(Get-VM -Name '{{.VmName}}*' | ?{$_.Name -eq '{{.VmName}}' } | Get-VMHardDiskDrive)[{{.Index}}]
 
 if (!$vmHardDiskDrivesObject){
-	throw "VM hard disk drive does not exist - {{.ControllerLocation}} {{.ControllerNumber}}"
+	throw "VM hard disk drive does not exist at index {{.Index}}"
 }
 
 $SetVmHardDiskDriveArgs = @{}
@@ -159,7 +158,7 @@ $SetVmHardDiskDriveArgs.SupportPersistentReservations=$vmHardDiskDrive.SupportPe
 $SetVmHardDiskDriveArgs.MaximumIops=$vmHardDiskDrive.MaximumIops
 $SetVmHardDiskDriveArgs.MinimumIops=$vmHardDiskDrive.MinimumIops
 $SetVmHardDiskDriveArgs.QosPolicyId=$vmHardDiskDrive.QosPolicyId
-$SetVmHardDiskDriveArgs.OverrideCacheAttributes=$vmHardDiskDrive.OverrideCacheAttributes	
+$SetVmHardDiskDriveArgs.OverrideCacheAttributes=$vmHardDiskDrive.OverrideCacheAttributes
 $SetVmHardDiskDriveArgs.AllowUnverifiedPaths=$true
 
 Set-VMHardDiskDrive @SetVmHardDiskDriveArgs
@@ -169,11 +168,10 @@ Set-VMHardDiskDrive @SetVmHardDiskDriveArgs
 func (c *ClientConfig) UpdateVmHardDiskDrive(
 	ctx context.Context,
 	vmName string,
+	index int,
+	controllerType api.ControllerType,
 	controllerNumber int32,
 	controllerLocation int32,
-	controllerType api.ControllerType,
-	toControllerNumber int32,
-	toControllerLocation int32,
 	path string,
 	diskNumber uint32,
 	resourcePoolName string,
@@ -186,8 +184,8 @@ func (c *ClientConfig) UpdateVmHardDiskDrive(
 	vmHardDiskDriveJson, err := json.Marshal(api.VmHardDiskDrive{
 		VmName:                        vmName,
 		ControllerType:                controllerType,
-		ControllerNumber:              toControllerNumber,
-		ControllerLocation:            toControllerLocation,
+		ControllerNumber:              controllerNumber,
+		ControllerLocation:            controllerLocation,
 		Path:                          path,
 		DiskNumber:                    diskNumber,
 		ResourcePoolName:              resourcePoolName,
@@ -204,8 +202,7 @@ func (c *ClientConfig) UpdateVmHardDiskDrive(
 
 	err = c.WinRmClient.RunFireAndForgetScript(ctx, updateVmHardDiskDriveTemplate, updateVmHardDiskDriveArgs{
 		VmName:              vmName,
-		ControllerNumber:    controllerNumber,
-		ControllerLocation:  controllerLocation,
+		Index:               index,
 		VmHardDiskDriveJson: string(vmHardDiskDriveJson),
 	})
 
@@ -213,22 +210,20 @@ func (c *ClientConfig) UpdateVmHardDiskDrive(
 }
 
 type deleteVmHardDiskDriveArgs struct {
-	VmName             string
-	ControllerNumber   int32
-	ControllerLocation int32
+	VmName string
+	Index  int
 }
 
 var deleteVmHardDiskDriveTemplate = template.Must(template.New("DeleteVmHardDiskDrive").Parse(`
 $ErrorActionPreference = 'Stop'
 
-@(Get-VMHardDiskDrive -VmName '{{.VmName}}' -ControllerNumber {{.ControllerNumber}} -ControllerLocation {{.ControllerLocation}}) | Remove-VMHardDiskDrive
+@(Get-VM -Name '{{.VmName}}*' | ?{$_.Name -eq '{{.VmName}}' } | Get-VMHardDiskDrive)[{{.Index}}] | Remove-VMHardDiskDrive
 `))
 
-func (c *ClientConfig) DeleteVmHardDiskDrive(ctx context.Context, vmname string, controllerNumber int32, controllerLocation int32) (err error) {
+func (c *ClientConfig) DeleteVmHardDiskDrive(ctx context.Context, vmName string, index int) (err error) {
 	err = c.WinRmClient.RunFireAndForgetScript(ctx, deleteVmHardDiskDriveTemplate, deleteVmHardDiskDriveArgs{
-		VmName:             vmname,
-		ControllerNumber:   controllerNumber,
-		ControllerLocation: controllerLocation,
+		VmName: vmName,
+		Index:  index,
 	})
 
 	return err
@@ -243,9 +238,9 @@ func (c *ClientConfig) CreateOrUpdateVmHardDiskDrives(ctx context.Context, vmNam
 	currentHardDiskDrivesLength := len(currentHardDiskDrives)
 	desiredHardDiskDrivesLength := len(hardDiskDrives)
 
+	// Step 1: 余剰ドライブを末尾から削除（インデックスシフトを回避）
 	for i := currentHardDiskDrivesLength - 1; i > desiredHardDiskDrivesLength-1; i-- {
-		currentHardDiskDrive := currentHardDiskDrives[i]
-		err = c.DeleteVmHardDiskDrive(ctx, vmName, currentHardDiskDrive.ControllerNumber, currentHardDiskDrive.ControllerLocation)
+		err = c.DeleteVmHardDiskDrive(ctx, vmName, i)
 		if err != nil {
 			return err
 		}
@@ -255,52 +250,92 @@ func (c *ClientConfig) CreateOrUpdateVmHardDiskDrives(ctx context.Context, vmNam
 		currentHardDiskDrivesLength = desiredHardDiskDrivesLength
 	}
 
-	for i := 0; i <= currentHardDiskDrivesLength-1; i++ {
-		currentHardDiskDrive := currentHardDiskDrives[i]
-		hardDiskDrive := hardDiskDrives[i]
-
-		err = c.UpdateVmHardDiskDrive(
-			ctx,
-			vmName,
-			currentHardDiskDrive.ControllerNumber,
-			currentHardDiskDrive.ControllerLocation,
-			hardDiskDrive.ControllerType,
-			hardDiskDrive.ControllerNumber,
-			hardDiskDrive.ControllerLocation,
-			hardDiskDrive.Path,
-			hardDiskDrive.DiskNumber,
-			hardDiskDrive.ResourcePoolName,
-			hardDiskDrive.SupportPersistentReservations,
-			hardDiskDrive.MaximumIops,
-			hardDiskDrive.MinimumIops,
-			hardDiskDrive.QosPolicyId,
-			hardDiskDrive.OverrideCacheAttributes,
-		)
-		if err != nil {
-			return err
+	// Step 2: コントローラタイプ変更を検知
+	// Set-VMHardDiskDrive には -ToControllerType パラメータがないため、
+	// コントローラタイプ変更時は Delete + Create で対応する必要がある。
+	// インデックスシフト問題を回避するため、変更がある場合は全ドライブを再作成する。
+	hasControllerTypeChange := false
+	for i := 0; i < currentHardDiskDrivesLength; i++ {
+		if currentHardDiskDrives[i].ControllerType != hardDiskDrives[i].ControllerType {
+			hasControllerTypeChange = true
+			break
 		}
 	}
 
-	for i := currentHardDiskDrivesLength - 1 + 1; i <= desiredHardDiskDrivesLength-1; i++ {
-		hardDiskDrive := hardDiskDrives[i]
-		err = c.CreateVmHardDiskDrive(
-			ctx,
-			vmName,
-			hardDiskDrive.ControllerType,
-			hardDiskDrive.ControllerNumber,
-			hardDiskDrive.ControllerLocation,
-			hardDiskDrive.Path,
-			hardDiskDrive.DiskNumber,
-			hardDiskDrive.ResourcePoolName,
-			hardDiskDrive.SupportPersistentReservations,
-			hardDiskDrive.MaximumIops,
-			hardDiskDrive.MinimumIops,
-			hardDiskDrive.QosPolicyId,
-			hardDiskDrive.OverrideCacheAttributes,
-		)
+	if hasControllerTypeChange {
+		// Step 3a: 全既存ドライブを末尾から削除し、全 desired を作成
+		for i := currentHardDiskDrivesLength - 1; i >= 0; i-- {
+			err = c.DeleteVmHardDiskDrive(ctx, vmName, i)
+			if err != nil {
+				return err
+			}
+		}
+		for i := 0; i < desiredHardDiskDrivesLength; i++ {
+			hardDiskDrive := hardDiskDrives[i]
+			err = c.CreateVmHardDiskDrive(
+				ctx,
+				vmName,
+				hardDiskDrive.ControllerType,
+				hardDiskDrive.ControllerNumber,
+				hardDiskDrive.ControllerLocation,
+				hardDiskDrive.Path,
+				hardDiskDrive.DiskNumber,
+				hardDiskDrive.ResourcePoolName,
+				hardDiskDrive.SupportPersistentReservations,
+				hardDiskDrive.MaximumIops,
+				hardDiskDrive.MinimumIops,
+				hardDiskDrive.QosPolicyId,
+				hardDiskDrive.OverrideCacheAttributes,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		// Step 3b: 通常パス（インデックスベースで Update + 新規 Create）
+		for i := 0; i < currentHardDiskDrivesLength; i++ {
+			hardDiskDrive := hardDiskDrives[i]
+			err = c.UpdateVmHardDiskDrive(
+				ctx,
+				vmName,
+				i,
+				hardDiskDrive.ControllerType,
+				hardDiskDrive.ControllerNumber,
+				hardDiskDrive.ControllerLocation,
+				hardDiskDrive.Path,
+				hardDiskDrive.DiskNumber,
+				hardDiskDrive.ResourcePoolName,
+				hardDiskDrive.SupportPersistentReservations,
+				hardDiskDrive.MaximumIops,
+				hardDiskDrive.MinimumIops,
+				hardDiskDrive.QosPolicyId,
+				hardDiskDrive.OverrideCacheAttributes,
+			)
+			if err != nil {
+				return err
+			}
+		}
 
-		if err != nil {
-			return err
+		for i := currentHardDiskDrivesLength; i < desiredHardDiskDrivesLength; i++ {
+			hardDiskDrive := hardDiskDrives[i]
+			err = c.CreateVmHardDiskDrive(
+				ctx,
+				vmName,
+				hardDiskDrive.ControllerType,
+				hardDiskDrive.ControllerNumber,
+				hardDiskDrive.ControllerLocation,
+				hardDiskDrive.Path,
+				hardDiskDrive.DiskNumber,
+				hardDiskDrive.ResourcePoolName,
+				hardDiskDrive.SupportPersistentReservations,
+				hardDiskDrive.MaximumIops,
+				hardDiskDrive.MinimumIops,
+				hardDiskDrive.QosPolicyId,
+				hardDiskDrive.OverrideCacheAttributes,
+			)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/api/vm_dvd_drive.go
+++ b/api/vm_dvd_drive.go
@@ -73,13 +73,12 @@ type HypervVmDvdDriveClient interface {
 	UpdateVmDvdDrive(
 		ctx context.Context,
 		vmName string,
+		index int,
 		controllerNumber int,
 		controllerLocation int,
-		toControllerNumber int,
-		toControllerLocation int,
 		path string,
 		resourcePoolName string,
 	) (err error)
-	DeleteVmDvdDrive(ctx context.Context, vmName string, controllerNumber int, controllerLocation int) (err error)
+	DeleteVmDvdDrive(ctx context.Context, vmName string, index int) (err error)
 	CreateOrUpdateVmDvdDrives(ctx context.Context, vmName string, dvdDrives []VmDvdDrive) (err error)
 }

--- a/api/vm_hard_disk_drive.go
+++ b/api/vm_hard_disk_drive.go
@@ -241,11 +241,10 @@ type HypervVmHardDiskDriveClient interface {
 	UpdateVmHardDiskDrive(
 		ctx context.Context,
 		vmName string,
+		index int,
+		controllerType ControllerType,
 		controllerNumber int32,
 		controllerLocation int32,
-		controllerType ControllerType,
-		toControllerNumber int32,
-		toControllerLocation int32,
 		path string,
 		diskNumber uint32,
 		resourcePoolName string,
@@ -255,6 +254,6 @@ type HypervVmHardDiskDriveClient interface {
 		qosPolicyId string,
 		overrideCacheAttributes CacheAttributes,
 	) (err error)
-	DeleteVmHardDiskDrive(ctx context.Context, vmname string, controllerNumber int32, controllerLocation int32) (err error)
+	DeleteVmHardDiskDrive(ctx context.Context, vmName string, index int) (err error)
 	CreateOrUpdateVmHardDiskDrives(ctx context.Context, vmName string, hardDiskDrives []VmHardDiskDrive) (err error)
 }


### PR DESCRIPTION
## Summary
- `Set-VMHardDiskDrive` で `controller_type` を IDE→SCSI に変更する際の `System.Object[]` 型変換エラーを修正
- HardDisk / DVD Drive の Update/Delete テンプレートを Network Adapter と同じインデックスベースアクセス `[{{.Index}}]` パターンに統一
- ControllerType 変更時は `Set-VMHardDiskDrive` の制約（`-ToControllerType` パラメータなし）のため、全ドライブ Delete + Create で処理

## Test plan
- [ ] `go build ./...` パス確認
- [ ] `go vet ./...` パス確認
- [ ] 実機テスト: Gen1 VM で IDE→SCSI コントローラタイプ変更が `terraform apply` で成功すること
- [ ] リグレッション: ディスク追加・削除・パス変更が正常動作すること
- [ ] リグレッション: DVD ドライブの追加・削除・更新が正常動作すること

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)