### PR TITLE
feat: Cloud-Init ISO リソース追加

### DIFF
--- a/api/cloudinit_iso.go
+++ b/api/cloudinit_iso.go
@@ -1,0 +1,17 @@
+package api
+
+import "context"
+
+type CloudInitIso struct {
+	DestinationIsoFilePath        string
+	UserData                      string
+	MetaData                      string
+	NetworkConfig                 string
+	ResolveDestinationIsoFilePath string
+}
+
+type HypervCloudInitIsoClient interface {
+	CreateOrUpdateCloudInitIso(ctx context.Context, destinationIsoFilePath string, userData string, metaData string, networkConfig string) (err error)
+	GetCloudInitIso(ctx context.Context, destinationIsoFilePath string) (result CloudInitIso, err error)
+	DeleteCloudInitIso(ctx context.Context, destinationIsoFilePath string) (err error)
+}

--- a/api/hyperv-winrm/cloudinit_iso.go
+++ b/api/hyperv-winrm/cloudinit_iso.go
@@ -1,0 +1,214 @@
+package hyperv_winrm
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"text/template"
+
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+type createOrUpdateCloudInitIsoArgs struct {
+	CloudInitIsoJson string
+}
+
+var createOrUpdateCloudInitIsoTemplate = template.Must(template.New("CreateOrUpdateCloudInitIso").Parse(`
+$ErrorActionPreference = 'Stop'
+
+$cloudInitIsoJson = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{{.CloudInitIsoJson}}'))
+$cloudInit = $cloudInitIsoJson | ConvertFrom-Json
+
+$destinationIsoFilePath = $cloudInit.DestinationIsoFilePath
+$resolveDestinationIsoFilePath = $ExecutionContext.InvokeCommand.ExpandString($destinationIsoFilePath)
+
+function New-TemporaryDirectory {
+  $parent = [System.IO.Path]::GetTempPath()
+  do {
+    $name = [System.IO.Path]::GetRandomFileName()
+    $item = New-Item -Path $parent -Name $name -ItemType "directory" -ErrorAction SilentlyContinue
+  } while (-not $item)
+  return $item.FullName
+}
+
+$typeDefinition = @'
+    public class ISOFile  {
+        public unsafe static void Create(string Path, object Stream, int BlockSize, int TotalBlocks) {
+            int bytes = 0;
+            byte[] buf = new byte[BlockSize];
+            var ptr = (System.IntPtr)(&bytes);
+            var o = System.IO.File.OpenWrite(Path);
+            var i = Stream as System.Runtime.InteropServices.ComTypes.IStream;
+
+            if (o != null) {
+                while (TotalBlocks-- > 0) {
+                    i.Read(buf, BlockSize, ptr); o.Write(buf, 0, bytes);
+                }
+
+                o.Flush(); o.Close();
+            }
+        }
+    }
+'@
+
+if (!('ISOFile' -as [type])) {
+    switch ($PSVersionTable.PSVersion.Major) {
+        { $_ -ge 7 } {
+            Add-Type -CompilerOptions "/unsafe" -TypeDefinition $typeDefinition
+        }
+        5 {
+            $compOpts = New-Object System.CodeDom.Compiler.CompilerParameters
+            $compOpts.CompilerOptions = "/unsafe"
+            Add-Type -CompilerParameters $compOpts -TypeDefinition $typeDefinition
+        }
+        default {
+            throw ("Unsupported PowerShell version.")
+        }
+    }
+}
+
+$tempDir = New-TemporaryDirectory
+try {
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText("$tempDir\user-data", $cloudInit.UserData, $utf8NoBom)
+    [System.IO.File]::WriteAllText("$tempDir\meta-data", $cloudInit.MetaData, $utf8NoBom)
+    if ($cloudInit.NetworkConfig) {
+        [System.IO.File]::WriteAllText("$tempDir\network-config", $cloudInit.NetworkConfig, $utf8NoBom)
+    }
+
+    try {
+        $image = New-Object -ComObject IMAPI2FS.MsftFileSystemImage -Property @{VolumeName = 'cidata'} -ErrorAction Stop
+        $image.ChooseImageDefaultsForMediaType(0x1)
+        $image.FileSystemsToCreate = 0x3
+    }
+    catch {
+        throw ("Failed to initialise ISO image. " + $_.exception.Message)
+    }
+
+    $targetFile = New-Item -Path $resolveDestinationIsoFilePath -ItemType File -Force -ErrorAction Stop
+    if (!$targetFile) {
+        throw ("Cannot create file " + $resolveDestinationIsoFilePath)
+    }
+
+    try {
+        $image.Root.AddTree($tempDir, $true)
+    }
+    catch {
+        throw ("Failed to add cloud-init files to ISO image. " + $_.exception.message)
+    }
+
+    try {
+        $result = $image.CreateResultImage()
+        [ISOFile]::Create($targetFile.FullName, $result.ImageStream, $result.BlockSize, $result.TotalBlocks)
+    }
+    catch {
+        throw ("Failed to write ISO file. " + $_.exception.Message)
+    }
+} finally {
+    Remove-Item $tempDir -Force -Recurse -ErrorAction SilentlyContinue
+}
+
+$metadata = @{}
+$metadata.DestinationIsoFilePath = $cloudInit.DestinationIsoFilePath
+$metadata.UserData = $cloudInit.UserData
+$metadata.MetaData = $cloudInit.MetaData
+$metadata.NetworkConfig = $cloudInit.NetworkConfig
+$metadata.ResolveDestinationIsoFilePath = $resolveDestinationIsoFilePath
+$metadata | ConvertTo-Json -Depth 100 | Out-File "$($resolveDestinationIsoFilePath).json" -Force
+`))
+
+func (c *ClientConfig) CreateOrUpdateCloudInitIso(ctx context.Context, destinationIsoFilePath string, userData string, metaData string, networkConfig string) (err error) {
+	cloudInitIsoJson, err := json.Marshal(api.CloudInitIso{
+		DestinationIsoFilePath: destinationIsoFilePath,
+		UserData:               userData,
+		MetaData:               metaData,
+		NetworkConfig:          networkConfig,
+	})
+
+	if err != nil {
+		return fmt.Errorf("error converting object to json: %s", err)
+	}
+
+	err = c.WinRmClient.RunFireAndForgetScript(ctx, createOrUpdateCloudInitIsoTemplate, createOrUpdateCloudInitIsoArgs{
+		CloudInitIsoJson: base64.StdEncoding.EncodeToString(cloudInitIsoJson),
+	})
+
+	if err != nil {
+		return fmt.Errorf("error creating or updating cloud-init iso: %v", err)
+	}
+
+	return err
+}
+
+type getCloudInitIsoArgs struct {
+	DestinationIsoFilePath string
+}
+
+var getCloudInitIsoTemplate = template.Must(template.New("GetCloudInitIso").Parse(`
+$ErrorActionPreference = 'Stop'
+$DestinationIsoFilePath='{{.DestinationIsoFilePath}}'
+$cloudInitIsoObject = $null
+
+$expandedDestinationIsoFilePath = $ExecutionContext.InvokeCommand.ExpandString($DestinationIsoFilePath)
+
+$metadataPath="$($expandedDestinationIsoFilePath).json"
+
+if (Test-Path $metadataPath) {
+	$metadata = Get-Content -Raw -Path $metadataPath | ConvertFrom-Json
+
+	$cloudInitIsoObject=@{}
+	$cloudInitIsoObject.DestinationIsoFilePath=$metadata.DestinationIsoFilePath
+	$cloudInitIsoObject.UserData=$metadata.UserData
+	$cloudInitIsoObject.MetaData=$metadata.MetaData
+	$cloudInitIsoObject.NetworkConfig=$metadata.NetworkConfig
+	$cloudInitIsoObject.ResolveDestinationIsoFilePath=$metadata.ResolveDestinationIsoFilePath
+} else {}
+
+if ($cloudInitIsoObject){
+	$cloudInitIso = ConvertTo-Json -InputObject $cloudInitIsoObject
+	$cloudInitIso
+} else {
+	"{}"
+}
+`))
+
+func (c *ClientConfig) GetCloudInitIso(ctx context.Context, destinationIsoFilePath string) (result api.CloudInitIso, err error) {
+	err = c.WinRmClient.RunScriptWithResult(ctx, getCloudInitIsoTemplate, getCloudInitIsoArgs{
+		DestinationIsoFilePath: destinationIsoFilePath,
+	}, &result)
+
+	return result, err
+}
+
+type deleteCloudInitIsoArgs struct {
+	DestinationIsoFilePath string
+}
+
+var deleteCloudInitIsoTemplate = template.Must(template.New("DeleteCloudInitIso").Parse(`
+$ErrorActionPreference = 'Stop'
+$DestinationIsoFilePath='{{.DestinationIsoFilePath}}'
+
+$expandedDestinationIsoFilePath = $ExecutionContext.InvokeCommand.ExpandString($DestinationIsoFilePath)
+
+if (Test-Path $expandedDestinationIsoFilePath) {
+	Remove-Item $expandedDestinationIsoFilePath -Force
+}
+
+$metadataPath="$($expandedDestinationIsoFilePath).json"
+if (Test-Path $metadataPath) {
+	Remove-Item $metadataPath -Force
+}
+`))
+
+func (c *ClientConfig) DeleteCloudInitIso(ctx context.Context, destinationIsoFilePath string) (err error) {
+	err = c.WinRmClient.RunFireAndForgetScript(ctx, deleteCloudInitIsoTemplate, deleteCloudInitIsoArgs{
+		DestinationIsoFilePath: destinationIsoFilePath,
+	})
+
+	if err != nil {
+		return fmt.Errorf("error deleting cloud-init iso: %v", err)
+	}
+
+	return err
+}

--- a/api/provider.go
+++ b/api/provider.go
@@ -12,6 +12,7 @@ type Client interface {
 	HypervVmStatusClient
 	HypervVmSwitchClient
 	HypervIsoImageClient
+	HypervCloudInitIsoClient
 }
 
 type Provider struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -195,6 +195,7 @@ func New(version string, commit string) func() *schema.Provider {
 				"hyperv_machine_instance": resourceHyperVMachineInstance(),
 				"hyperv_vhd":              resourceHyperVVhd(),
 				"hyperv_iso_image":        resourceHyperVIsoImage(),
+				"hyperv_cloudinit_iso":    resourceHyperVCloudInitIso(),
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"hyperv_network_switch":   dataSourceHyperVNetworkSwitch(),

--- a/internal/provider/resource_hyperv_cloudinit_iso.go
+++ b/internal/provider/resource_hyperv_cloudinit_iso.go
@@ -1,0 +1,159 @@
+package provider
+
+import (
+	"context"
+	log "log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+const (
+	ReadCloudInitIsoTimeout   = 1 * time.Minute
+	CreateCloudInitIsoTimeout = 5 * time.Minute
+	UpdateCloudInitIsoTimeout = 5 * time.Minute
+	DeleteCloudInitIsoTimeout = 1 * time.Minute
+)
+
+func resourceHyperVCloudInitIso() *schema.Resource {
+	return &schema.Resource{
+		Description: "This resource allows you to manage Cloud-Init compatible ISO images on the Hyper-V host. The ISO is created with the volume label `cidata` for NoCloud datasource compatibility.",
+		Timeouts: &schema.ResourceTimeout{
+			Read:   schema.DefaultTimeout(ReadCloudInitIsoTimeout),
+			Create: schema.DefaultTimeout(CreateCloudInitIsoTimeout),
+			Update: schema.DefaultTimeout(UpdateCloudInitIsoTimeout),
+			Delete: schema.DefaultTimeout(DeleteCloudInitIsoTimeout),
+		},
+		CreateContext: resourceHyperVCloudInitIsoCreate,
+		ReadContext:   resourceHyperVCloudInitIsoRead,
+		UpdateContext: resourceHyperVCloudInitIsoUpdate,
+		DeleteContext: resourceHyperVCloudInitIsoDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"destination_iso_file_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Remote path for the generated cloud-init ISO file.",
+			},
+			"user_data": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Cloud-init user-data content (typically #cloud-config YAML).",
+			},
+			"meta_data": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Cloud-init meta-data content (YAML with instance-id, local-hostname, etc.).",
+			},
+			"network_config": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "Cloud-init network-config content (Networking v2 YAML).",
+			},
+			"resolve_destination_iso_file_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The actual remote ISO file path that was used.",
+			},
+		},
+	}
+}
+
+func resourceHyperVCloudInitIsoCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO][cloudinit-iso][create] creating cloud-init iso: %#v", d)
+	c := meta.(api.Client)
+
+	destinationIsoFilePath := (d.Get("destination_iso_file_path")).(string)
+	userData := (d.Get("user_data")).(string)
+	metaData := (d.Get("meta_data")).(string)
+	networkConfig := (d.Get("network_config")).(string)
+
+	if destinationIsoFilePath == "" {
+		return diag.Errorf("[ERROR][cloudinit-iso][create] destination_iso_file_path argument is required")
+	}
+
+	err := c.CreateOrUpdateCloudInitIso(ctx, destinationIsoFilePath, userData, metaData, networkConfig)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(destinationIsoFilePath)
+	log.Printf("[INFO][cloudinit-iso][create] created cloud-init iso: %#v", d)
+
+	return resourceHyperVCloudInitIsoRead(ctx, d, meta)
+}
+
+func resourceHyperVCloudInitIsoRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO][cloudinit-iso][read] reading cloud-init iso: %#v", d)
+	c := meta.(api.Client)
+
+	destinationIsoFilePath := d.Id()
+
+	cloudInitIso, err := c.GetCloudInitIso(ctx, destinationIsoFilePath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO][cloudinit-iso][read] retrieved cloud-init iso: %+v", cloudInitIso)
+
+	if err := d.Set("destination_iso_file_path", cloudInitIso.DestinationIsoFilePath); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("user_data", cloudInitIso.UserData); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("meta_data", cloudInitIso.MetaData); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("network_config", cloudInitIso.NetworkConfig); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("resolve_destination_iso_file_path", cloudInitIso.ResolveDestinationIsoFilePath); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO][cloudinit-iso][read] read cloud-init iso: %#v", d)
+
+	return nil
+}
+
+func resourceHyperVCloudInitIsoUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO][cloudinit-iso][update] updating cloud-init iso: %#v", d)
+	c := meta.(api.Client)
+
+	destinationIsoFilePath := d.Id()
+	userData := (d.Get("user_data")).(string)
+	metaData := (d.Get("meta_data")).(string)
+	networkConfig := (d.Get("network_config")).(string)
+
+	err := c.CreateOrUpdateCloudInitIso(ctx, destinationIsoFilePath, userData, metaData, networkConfig)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO][cloudinit-iso][update] updated cloud-init iso: %#v", d)
+
+	return resourceHyperVCloudInitIsoRead(ctx, d, meta)
+}
+
+func resourceHyperVCloudInitIsoDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO][cloudinit-iso][delete] deleting cloud-init iso: %#v", d)
+	c := meta.(api.Client)
+
+	destinationIsoFilePath := d.Id()
+
+	err := c.DeleteCloudInitIso(ctx, destinationIsoFilePath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO][cloudinit-iso][delete] deleted cloud-init iso: %#v", d)
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- `hyperv_cloudinit_iso` リソースを新規追加
- Cloud-Init NoCloud datasource 互換の ISO を Hyper-V ホスト上で直接生成
- user-data, meta-data, network-config を指定可能
- IMAPI2FS COM オブジェクトで ISO 生成、volume label は `cidata`

## Changes
- `api/cloudinit_iso.go`: 型定義・インターフェース
- `api/hyperv-winrm/cloudinit_iso.go`: PowerShell テンプレート（Base64 エンコード対応）
- `internal/provider/resource_hyperv_cloudinit_iso.go`: Terraform リソース CRUD
- `api/provider.go`, `internal/provider/provider.go`: リソース登録

## Test plan
- [ ] Cloud-Init ISO 生成（user-data + meta-data）
- [ ] network-config 付き ISO 生成
- [ ] ISO 更新（content 変更）
- [ ] ISO 削除（メタデータファイル含む）
- [ ] Ubuntu Cloud Image での動作確認（Linux ISO アップロード後）

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)