### PR TITLE
feat: provider.insecure を go-wsman の WithInsecureSkipVerify に伝播

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/r4sd/go-wsman v0.0.0-20260510112413-c6a45a3c107c // indirect
+	github.com/r4sd/go-wsman v0.0.0-20260510143113-8c66e1a969a0 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXq
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/r4sd/go-wsman v0.0.0-20260510112413-c6a45a3c107c h1:BuKRAehDRd3LlnQlCfVLAzudFlPSnUDLY648IkfiV0U=
 github.com/r4sd/go-wsman v0.0.0-20260510112413-c6a45a3c107c/go.mod h1:ZwgnmLAq4uxW3yhEzp5AQLqM5d+R/S++/LwoTYhVygg=
+github.com/r4sd/go-wsman v0.0.0-20260510143113-8c66e1a969a0 h1:zcyI0CDjIS6F45RO/ItNkE4BjPeDRq69zcmpP/cPEJ4=
+github.com/r4sd/go-wsman v0.0.0-20260510143113-8c66e1a969a0/go.mod h1:ZwgnmLAq4uxW3yhEzp5AQLqM5d+R/S++/LwoTYhVygg=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -259,6 +259,11 @@ func getHypervProvider(config *Config) (hypervProvider *api.Provider, err error)
 //
 // 認証: 現行の Provider 設定 (NTLM / Basic / Cert) のうち、Phase A では NTLM のみサポート。
 // Kerberos / Cert は Phase B 以降で必要になったタイミングで対応する。
+//
+// TLS 証明書検証:
+//   - provider 設定 insecure=false (デフォルト): 証明書検証あり
+//   - provider 設定 insecure=true: WithInsecureSkipVerify() で検証スキップ
+//     (homelab のように自己署名証明書を使う環境向け)
 func newWsmanClient(config *Config) (*gowsman.Client, error) {
 	scheme := "http"
 	if config.HTTPS {
@@ -269,6 +274,9 @@ func newWsmanClient(config *Config) (*gowsman.Client, error) {
 	opts := []gowsmanproto.ClientOption{}
 	if config.NTLM {
 		opts = append(opts, gowsmanproto.WithNTLM(config.User, config.Password))
+	}
+	if config.Insecure {
+		opts = append(opts, gowsmanproto.WithInsecureSkipVerify())
 	}
 
 	return gowsman.NewClient(endpoint, opts...)


### PR DESCRIPTION
## Summary

go-wsman PR #47 (https://github.com/r4sd/go-wsman/pull/47) で TLS 証明書検証がデフォルト有効化された。自己署名証明書を使う環境では \`WithInsecureSkipVerify()\` の明示が必要なため、Provider 設定の \`insecure=true\` を伝播させる。

## 変更内容

| 項目 | 内容 |
|------|------|
| go.mod | \`github.com/r4sd/go-wsman\` を WithInsecureSkipVerify 対応版へ更新 |
| \`internal/provider/config.go\` | \`config.Insecure=true\` 時に \`gowsmanproto.WithInsecureSkipVerify()\` を opts に追加 |

## 互換性マトリクス

\`\`\`
HYPERV_USE_WSMAN | provider.insecure | 動作
─────────────────┼───────────────────┼────────────────────────────
未設定           | -                 | PowerShell 経路 (従来通り)
=1               | true              | wsman 経路 + 証明書検証スキップ ← homelab 想定
=1               | false             | wsman 経路 + 証明書検証あり (本番想定)
\`\`\`

既存ユーザーの設定変更は不要。homelab 等で既に \`insecure=true\` を指定していれば、wsman 経路に切り替えてもそのまま動作する。

## Test plan

- [x] \`go build ./...\` 成功
- [x] \`go vet ./...\` 問題なし
- [x] \`gofmt -l\` クリーン
- [ ] 実機 acc test (homelab で \`HYPERV_USE_WSMAN=1\` かつ \`provider.insecure=true\` で確認)

## 関連

- 上流 (go-wsman): https://github.com/r4sd/go-wsman/pull/47 — WithInsecureSkipVerify() 新設
- Phase A: #30 — go-wsman 移行基盤
- Phase B: #32 — VhdExists 移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)