### PR TITLE
fix: VM destroy時のTurnOffオプション追加とVHDリネーム修正

### DIFF
--- a/api/hyperv-winrm/vhd.go
+++ b/api/hyperv-winrm/vhd.go
@@ -242,6 +242,18 @@ if ($vhd -and !(Test-Path $vhd.Path)) {
         Expand-Downloads -FolderPath $pathDirectory
 
         Pop-Location
+
+        # ダウンロード/展開されたファイルを$vhd.Pathにリネーム
+        if (!(Test-Path $vhd.Path)) {
+            $targetExtension = [System.IO.Path]::GetExtension($vhd.Path)
+            $vhdFiles = Get-ChildItem -Path $pathDirectory -File | Where-Object {
+                $_.Extension -ieq $targetExtension -and $_.Name -ine $pathFilename
+            }
+            if ($vhdFiles) {
+                $sourceFile = if ($vhdFiles -is [array]) { $vhdFiles[0] } else { $vhdFiles }
+                Rename-Item -Path $sourceFile.FullName -NewName $pathFilename -Force
+            }
+        }
     } else {
         $NewVhdArgs = @{}
         $NewVhdArgs.Path = $vhd.Path

--- a/api/hyperv-winrm/vm_status.go
+++ b/api/hyperv-winrm/vm_status.go
@@ -41,6 +41,7 @@ type updateVmStatusArgs struct {
 	Timeout      uint32
 	PollPeriod   uint32
 	VmStatusJson string
+	TurnOff      bool
 }
 
 var updateVmStatusTemplate = template.Must(template.New("UpdateVmStatus").Parse(`
@@ -138,9 +139,9 @@ if ($vmObject.State -ne $state) {
         } else {
             throw "Unable to change VM $($vmName) state $($vmObject.State) to Running state"
         }
-    } elseif ($state -eq [Microsoft.HyperV.PowerShell.VMState]::Off) { 
-        if ($vmObject.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running -or $vmObject.State -eq [Microsoft.HyperV.PowerShell.VMState]::Paused) { 
-            Stop-VM -Name $vmName -force
+    } elseif ($state -eq [Microsoft.HyperV.PowerShell.VMState]::Off) {
+        if ($vmObject.State -eq [Microsoft.HyperV.PowerShell.VMState]::Running -or $vmObject.State -eq [Microsoft.HyperV.PowerShell.VMState]::Paused) {
+            {{if .TurnOff}}Stop-VM -Name $vmName -TurnOff -Force{{else}}Stop-VM -Name $vmName -Force{{end}}
             Start-Sleep -Seconds $pollPeriod
             Wait-IsInFinalTransitionState -Name $vmName -Timeout $timeout -PollPeriod $pollPeriod
         } else {
@@ -164,6 +165,7 @@ func (c *ClientConfig) UpdateVmStatus(
 	timeout uint32,
 	pollPeriod uint32,
 	state api.VmState,
+	turnOff bool,
 ) (err error) {
 	vmStatusJson, err := json.Marshal(api.VmStatus{
 		State: state,
@@ -178,6 +180,7 @@ func (c *ClientConfig) UpdateVmStatus(
 		Timeout:      timeout,
 		PollPeriod:   pollPeriod,
 		VmStatusJson: string(vmStatusJson),
+		TurnOff:      turnOff,
 	})
 
 	return err

--- a/api/vm_status.go
+++ b/api/vm_status.go
@@ -165,5 +165,6 @@ type HypervVmStatusClient interface {
 		timeout uint32,
 		pollPeriod uint32,
 		state VmState,
+		turnOff bool,
 	) (err error)
 }

--- a/docs/resources/machine_instance.md
+++ b/docs/resources/machine_instance.md
@@ -232,6 +232,7 @@ resource "hyperv_machine_instance" "default" {
 - `state` (String) Valid values to use are `Running`, `Off`. Specifies if the machine instance will be running or off.
 - `static_memory` (Boolean) Specifies if the machine instance will use static memory.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `turn_off_on_destroy` (Boolean) If true, the VM will be turned off (hard power off) instead of attempting a graceful shutdown when destroyed. This is useful for VMs that do not respond to Hyper-V shutdown integration services, such as Linux K8s nodes.
 - `vm_firmware` (Block List, Max: 1) (see [below for nested schema](#nestedblock--vm_firmware))
 - `vm_processor` (Block List, Max: 1) (see [below for nested schema](#nestedblock--vm_processor))
 - `wait_for_ips_poll_period` (Number) The amount of time in seconds to wait between trying to get ip addresses for network cards on the virtual machine.

--- a/internal/provider/resource_hyperv_machine_instance.go
+++ b/internal/provider/resource_hyperv_machine_instance.go
@@ -333,6 +333,13 @@ func resourceHyperVMachineInstance() *schema.Resource {
 				Description:      "Valid values to use are `Running`, `Off`. Specifies if the machine instance will be running or off.",
 			},
 
+			"turn_off_on_destroy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true, the VM will be turned off (hard power off) instead of attempting a graceful shutdown when destroyed. This is useful for VMs that do not respond to Hyper-V shutdown integration services, such as Linux K8s nodes.",
+			},
+
 			"wait_for_state_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -1163,7 +1170,7 @@ func resourceHyperVMachineInstanceCreate(ctx context.Context, d *schema.Resource
 		}
 	}
 
-	err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, state)
+	err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, state, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1587,7 +1594,7 @@ func resourceHyperVMachineInstanceUpdate(ctx context.Context, d *schema.Resource
 		}
 
 		state := api.ToVmState((d.Get("state")).(string))
-		err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, state)
+		err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, state, false)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -1611,7 +1618,8 @@ func resourceHyperVMachineInstanceDelete(ctx context.Context, d *schema.Resource
 	}
 
 	state := api.VmState_Off
-	err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, state)
+	turnOff := d.Get("turn_off_on_destroy").(bool)
+	err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, state, turnOff)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1640,7 +1648,7 @@ func turnOffVmIfOn(ctx context.Context, data *schema.ResourceData, client api.Cl
 				return err
 			}
 
-			err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, api.VmState_Off)
+			err = client.UpdateVmStatus(ctx, name, waitForStateTimeout, waitForStatePollPeriod, api.VmState_Off, false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## 概要

上流 taliesins/terraform-provider-hyperv の Issue #275, #196 に対応する fork 独自パッチ。

### 変更内容

- **#275**: `turn_off_on_destroy` 属性を追加し、destroy時に `Stop-VM -TurnOff` で即時電源断できるように
  - Linux K8s等のVMが graceful shutdown に応答せず `Remove-VM` が失敗する問題を解決
- **#196**: source からVHDをダウンロードした際、`path` で指定したファイル名にリネームされない問題を修正

### 影響範囲

- `api/hyperv-winrm/vhd.go` (+12): ダウンロード後のリネーム処理追加
- `api/hyperv-winrm/vm_status.go` (+5/-3): `TurnOff` フラグを Stop-VM テンプレートに追加
- `api/vm_status.go` (+1): インターフェース変更
- `internal/provider/resource_hyperv_machine_instance.go` (+10/-3): `turn_off_on_destroy` schema 追加、`UpdateVmStatus` 呼び出しに引数追加

### 検証

- ローカルビルド: `go build ./...` 成功
- 静的解析: `go vet ./...` クリーン
- ユニットテスト: `go test ./...` 全 pass

### 補足

このブランチは元々 `fix/vm-destroy-turnoff-and-vhd-rename` (commit d2d4cf4, 2026-03-01) として用意されていたが、merge-base が古くなっていたため master ベースで cherry-pick して再構築した。

## Test plan

- [ ] CI が通過すること
- [ ] (任意) homelab 環境で `turn_off_on_destroy = true` を指定して Linux K8s ノード VM の destroy が即時完了することを確認
- [ ] (任意) `source` を指定した VHD 作成で、`path` で指定したファイル名にリネームされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)