### PR TITLE
ci: dependabot の patch/minor を CI 通過後に自動マージ

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+# dependabot の PR のうち patch/minor 更新を CI 通過後に自動マージする。
+# major 更新は breaking の可能性があるため自動マージせず手動レビューに回す。
+# auto-merge は ruleset (main-protection) の required status checks 通過を待ってから実行される。
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch/minor
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Enable auto-merge for patch/minor
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

dependabot の patch/minor 更新を CI 通過後に自動マージする (go-wsman と同じ仕組み)。major は breaking 可能性があるため手動レビュー。

## 仕組み

- `dependabot/fetch-metadata` (SHA ピン留め v3.1.0) で update-type 判定
- patch/minor → `gh pr merge --auto --squash`
- major → 手動
- ruleset `main-protection` の required checks (go build / go test / golangci-lint / go mod download / terraform providers schema) 通過後にマージ

## 安全性

- 既存の required check 5 件が安全網 (CI で破壊的変更を検出)
- リリースは手動タグ (workflow_dispatch) のため、auto-merge → 自動リリース連鎖はなし
- 対象 ecosystem: gomod + github-actions の patch/minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)