### PR TITLE
feat: GetVhd を go-wsman 経由に移行 (Phase B-X.1)

### DIFF
--- a/api/hyperv-wsman/vhd.go
+++ b/api/hyperv-wsman/vhd.go
@@ -2,6 +2,7 @@ package hyperv_wsman
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/taliesins/terraform-provider-hyperv/api"
@@ -22,4 +23,37 @@ func (c *ClientConfig) VhdExists(ctx context.Context, path string) (api.VhdExist
 		return api.VhdExists{Exists: false}, nil
 	}
 	return api.VhdExists{Exists: true}, nil
+}
+
+// GetVhd は go-wsman 経由で VHD/VHDX の構成情報を取得する。
+//
+// PowerShell 版 (hyperv_winrm.GetVhd) と互換性のあるサブセット。Msvm_VirtualHardDiskSettingData
+// (CIM) で取得できる構成情報のみ返し、物理状態 (FileSize/Attached/DiskNumber/
+// FragmentationPercentage 等) は未設定のまま (ゼロ値)。
+//
+// provider 側 (`resource_hyperv_vhd.go` / `data_source_hyperv_vhd.go`) で実際に
+// 参照されているフィールドは Path / VhdType / ParentPath / Size / BlockSize /
+// LogicalSectorSize / PhysicalSectorSize の 7 件のみで、いずれも本実装でカバー済。
+func (c *ClientConfig) GetVhd(ctx context.Context, path string) (api.Vhd, error) {
+	sd, err := c.WsmanClient.GetVirtualHardDisk(ctx, path)
+	if err != nil {
+		return api.Vhd{}, fmt.Errorf("hyperv-wsman: GetVhd %q: %w", path, err)
+	}
+
+	// CIM 値 (uint16) は api.VhdType / api.VhdFormat と完全一致 (Fixed=2/Dynamic=3/Differencing=4、
+	// VHD=2/VHDX=3/VHDSet=4)。直接キャストで安全に変換できる。
+	return api.Vhd{
+		Path:               sd.Path,
+		BlockSize:          sd.BlockSize,
+		LogicalSectorSize:  sd.LogicalSectorSize,
+		PhysicalSectorSize: sd.PhysicalSectorSize,
+		ParentPath:         sd.ParentPath,
+		Size:               sd.MaxInternalSize, // CIM の論理サイズ
+		VhdType:            api.VhdType(sd.VirtualDiskType),
+		VhdFormat:          api.VhdFormat(sd.VirtualDiskFormat),
+		// FileSize / MinimumSize / Attached / DiskNumber / Number /
+		// FragmentationPercentage / Alignment / DiskIdentifier は CIM の
+		// Msvm_VirtualHardDiskSettingData では取得できないためゼロ値。
+		// provider 側で未参照のため互換性に影響なし。
+	}, nil
 }

--- a/api/hyperv-wsman/vhd_test.go
+++ b/api/hyperv-wsman/vhd_test.go
@@ -10,9 +10,9 @@ import (
 // TestClientConfig_ImplementsHypervVhdClient は ClientConfig が
 // api.HypervVhdClient を実装することを検証する。
 //
-// 重要: VhdExists は本パッケージで定義されているため、シャドウイング (override)
-// が効いて hyperv-winrm の実装ではなく hyperv-wsman の実装が呼ばれる。
-// 残りの 4 メソッド (CreateOrUpdateVhd / ResizeVhd / GetVhd / DeleteVhd) は
+// 重要: VhdExists / GetVhd は本パッケージで定義されているため、シャドウイング
+// (override) が効いて hyperv-winrm の実装ではなく hyperv-wsman の実装が呼ばれる。
+// 残りの 3 メソッド (CreateOrUpdateVhd / ResizeVhd / DeleteVhd) は
 // 埋め込みの hyperv_winrm.ClientConfig から promotion される。
 func TestClientConfig_ImplementsHypervVhdClient(t *testing.T) {
 	// 型レベルでインターフェース実装を確認する (実行時にメソッド呼び出しはしない)
@@ -23,9 +23,9 @@ func TestClientConfig_ImplementsHypervVhdClient(t *testing.T) {
 	cType := reflect.TypeOf((*ClientConfig)(nil))
 	for _, methodName := range []string{
 		"VhdExists",         // ← 本パッケージで定義 (シャドウイング)
+		"GetVhd",            // ← 本パッケージで定義 (シャドウイング、Phase B-X.1)
 		"CreateOrUpdateVhd", // ← hyperv-winrm から promotion
 		"ResizeVhd",         // ← hyperv-winrm から promotion
-		"GetVhd",            // ← hyperv-winrm から promotion
 		"DeleteVhd",         // ← hyperv-winrm から promotion
 	} {
 		if _, ok := cType.MethodByName(methodName); !ok {
@@ -53,5 +53,26 @@ func TestClientConfig_VhdExists_DefinedInWsmanPackage(t *testing.T) {
 	}
 	if method.Type.NumOut() != 2 { // VhdExists + error
 		t.Errorf("VhdExists signature mismatch: NumOut=%d", method.Type.NumOut())
+	}
+}
+
+// TestClientConfig_GetVhd_DefinedInWsmanPackage は GetVhd が
+// hyperv-wsman パッケージ自身で定義されていることを reflect 経由で検証する。
+//
+// これにより hyperv_winrm.ClientConfig.GetVhd ではなく、本パッケージの
+// 実装が呼ばれることが保証される (シャドウイング)。
+func TestClientConfig_GetVhd_DefinedInWsmanPackage(t *testing.T) {
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	method, ok := cType.MethodByName("GetVhd")
+	if !ok {
+		t.Fatal("ClientConfig should have GetVhd method")
+	}
+
+	// シグネチャ: (c *ClientConfig).GetVhd(ctx, path) (api.Vhd, error)
+	if method.Type.NumIn() != 3 { // receiver + ctx + path
+		t.Errorf("GetVhd signature mismatch: NumIn=%d, want 3", method.Type.NumIn())
+	}
+	if method.Type.NumOut() != 2 { // api.Vhd + error
+		t.Errorf("GetVhd signature mismatch: NumOut=%d, want 2", method.Type.NumOut())
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260510143113-8c66e1a969a0
+	github.com/r4sd/go-wsman v0.0.0-20260528163136-fd43c067d8f4
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260510143113-8c66e1a969a0 h1:zcyI0CDjIS6F45RO/ItNkE4BjPeDRq69zcmpP/cPEJ4=
-github.com/r4sd/go-wsman v0.0.0-20260510143113-8c66e1a969a0/go.mod h1:ZwgnmLAq4uxW3yhEzp5AQLqM5d+R/S++/LwoTYhVygg=
+github.com/r4sd/go-wsman v0.0.0-20260528163136-fd43c067d8f4 h1:0FAzh8o6nc6l/K4u/MX+OjL/pRk/PVJP5nXuPHTDwCM=
+github.com/r4sd/go-wsman v0.0.0-20260528163136-fd43c067d8f4/go.mod h1:uLiKo3lIZJe2MwVjBsjOTPzkTuWJFc4/gf7L1mVqOb8=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=


### PR DESCRIPTION
## 概要

VHD 残メソッド 4 件のうち、最も低リスクな **Read 系 `GetVhd`** を go-wsman 経由に切り替え。Phase B-X (VHD 統合完了) の最初の 1 本。

## 背景

go-wsman 側で Priority-High parity が全完了 (#73 直近マージ) し、provider 側で wsman 経路を 1 メソッドずつ実装するフェーズに入った。`VhdExists` (Phase B, #32) と同じシャドウイングパターンを踏襲。

## 実装

| マッピング | go-wsman (`Msvm_VirtualHardDiskSettingData`) | api.Vhd |
|---|---|---|
| Path | `Path` | `Path` |
| BlockSize | `BlockSize` | `BlockSize` |
| LogicalSectorSize | `LogicalSectorSize` | `LogicalSectorSize` |
| PhysicalSectorSize | `PhysicalSectorSize` | `PhysicalSectorSize` |
| ParentPath | `ParentPath` | `ParentPath` |
| Size | `MaxInternalSize` (CIM 論理サイズ) | `Size` |
| VhdType | `VirtualDiskType` uint16 | `api.VhdType` (値完全一致) |
| VhdFormat | `VirtualDiskFormat` uint16 | `api.VhdFormat` (値完全一致) |

uint16 値が **CIM/api 両方で完全一致** (Fixed=2/Dynamic=3/Differencing=4、VHD=2/VHDX=3/VHDSet=4) のため直接キャストで安全。

## 互換性

provider 側 (`resource_hyperv_vhd.go` / `data_source_hyperv_vhd.go`) で実際に参照される Vhd フィールドは **7 つだけ** (Path / VhdType / ParentPath / Size / BlockSize / LogicalSectorSize / PhysicalSectorSize) で **全て本実装でカバー**。

未参照のフィールド (FileSize / Attached / DiskNumber / Number / MinimumSize / FragmentationPercentage / Alignment / DiskIdentifier) は CIM の `Msvm_VirtualHardDiskSettingData` では取得できないためゼロ値のまま。provider が使わないので影響なし。

## 依存更新

- `go-wsman` を 2026-05-10 版 → 2026-05-29 版 (`fd43c067d8f4`) に更新
- 反映される変更: #65/#66 CIM タグ整合修正、#50 MVSSD 10 フィールド追加、#51 Gen2 Firmware、#53 NIC VLAN、#71 UpdateVm 等

## 検証

- `TestClientConfig_GetVhd_DefinedInWsmanPackage` 追加 (シャドウイング確認)
- `TestClientConfig_ImplementsHypervVhdClient` 更新 (GetVhd を shadow リストに移動)
- `go test -race ./api/hyperv-wsman/... -count=1`: pass
- `go vet ./...` / `go build ./...`: クリーン
- 実機 acc test (`HYPERV_USE_WSMAN=1`) は homelab で別途実施

## Phase B-X 残

| Step | 内容 | go-wsman 側 |
|---|---|---|
| B-X.2 | ResizeVhd | #49 `ResizeVirtualHardDisk` ✓ |
| B-X.3 | CreateOrUpdateVhd | CIM 経由 (source コピー除く) |
| B-X.4 | DeleteVhd | 案 D = WinRM 薄ラッパー (ファイル操作) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)