### PR TITLE
feat: ResizeVhd を go-wsman 経由に移行 (Phase B-X.2)

### DIFF
--- a/api/hyperv-wsman/vhd.go
+++ b/api/hyperv-wsman/vhd.go
@@ -25,6 +25,32 @@ func (c *ClientConfig) VhdExists(ctx context.Context, path string) (api.VhdExist
 	return api.VhdExists{Exists: true}, nil
 }
 
+// ResizeVhd は go-wsman 経由で既存 VHD/VHDX のサイズ (MaxInternalSize) を変更する。
+//
+// PowerShell 版 (hyperv_winrm.ResizeVhd) は同期 (Resize-VHD がブロック完了) だが、
+// CIM の Msvm_ImageManagementService.ResizeVirtualHardDisk は ReturnValue=0 で
+// 同期完了、4096 で非同期 Job 開始。Hyper-V の通常挙動では Resize は同期完了する
+// ことが多いため、現状は同期成功のみ素通し、非同期開始時は WARN ログのみ出して
+// 待機しない (Phase B-X.X 等で Job 完了待ちヘルパーを別実装予定)。
+//
+// 制約 (CIM 仕様):
+//   - Fixed VHD: 拡大のみ可
+//   - Dynamic/Differencing: MaxInternalSize の縮小も可 (実データ末尾まで)
+//   - VM へアタッチ中: オフライン状態のみ縮小可
+func (c *ClientConfig) ResizeVhd(ctx context.Context, path string, size uint64) error {
+	jobRef, err := c.WsmanClient.ResizeVirtualHardDisk(ctx, path, size)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: ResizeVhd %q: %w", path, err)
+	}
+	if jobRef != "" {
+		// ReturnValue=4096 (非同期開始): provider 側は同期完了を期待するが、
+		// 現状は Job 完了待ちヘルパー未実装のため WARN ログのみ。
+		// 実用上は Resize は同期完了が多いためレアケース。問題化したら別 PR で実装。
+		log.Printf("[WARN][hyperv-wsman] ResizeVhd started asynchronously (jobRef=%s), not waiting for completion. Path=%q Size=%d", jobRef, path, size)
+	}
+	return nil
+}
+
 // GetVhd は go-wsman 経由で VHD/VHDX の構成情報を取得する。
 //
 // PowerShell 版 (hyperv_winrm.GetVhd) と互換性のあるサブセット。Msvm_VirtualHardDiskSettingData

--- a/api/hyperv-wsman/vhd_test.go
+++ b/api/hyperv-wsman/vhd_test.go
@@ -24,8 +24,8 @@ func TestClientConfig_ImplementsHypervVhdClient(t *testing.T) {
 	for _, methodName := range []string{
 		"VhdExists",         // ← 本パッケージで定義 (シャドウイング)
 		"GetVhd",            // ← 本パッケージで定義 (シャドウイング、Phase B-X.1)
+		"ResizeVhd",         // ← 本パッケージで定義 (シャドウイング、Phase B-X.2)
 		"CreateOrUpdateVhd", // ← hyperv-winrm から promotion
-		"ResizeVhd",         // ← hyperv-winrm から promotion
 		"DeleteVhd",         // ← hyperv-winrm から promotion
 	} {
 		if _, ok := cType.MethodByName(methodName); !ok {
@@ -74,5 +74,23 @@ func TestClientConfig_GetVhd_DefinedInWsmanPackage(t *testing.T) {
 	}
 	if method.Type.NumOut() != 2 { // api.Vhd + error
 		t.Errorf("GetVhd signature mismatch: NumOut=%d, want 2", method.Type.NumOut())
+	}
+}
+
+// TestClientConfig_ResizeVhd_DefinedInWsmanPackage は ResizeVhd が
+// hyperv-wsman パッケージ自身で定義されていることを reflect 経由で検証する (Phase B-X.2)。
+func TestClientConfig_ResizeVhd_DefinedInWsmanPackage(t *testing.T) {
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	method, ok := cType.MethodByName("ResizeVhd")
+	if !ok {
+		t.Fatal("ClientConfig should have ResizeVhd method")
+	}
+
+	// シグネチャ: (c *ClientConfig).ResizeVhd(ctx, path, size) error
+	if method.Type.NumIn() != 4 { // receiver + ctx + path + size
+		t.Errorf("ResizeVhd signature mismatch: NumIn=%d, want 4", method.Type.NumIn())
+	}
+	if method.Type.NumOut() != 1 { // error
+		t.Errorf("ResizeVhd signature mismatch: NumOut=%d, want 1", method.Type.NumOut())
 	}
 }


### PR DESCRIPTION
## 概要

VHD 残メソッド 2 件目。`Msvm_ImageManagementService.ResizeVirtualHardDisk` を呼ぶシャドウイング実装。

## 同期/非同期の差異

| | PowerShell 版 | 本実装 (go-wsman) |
|---|---|---|
| 呼び出し | `Resize-VHD` (内部で CIM 呼出をブロック) | CIM 直叩き |
| ReturnValue=0 | (内部処理、見えない) | 同期完了として素通し |
| ReturnValue=4096 | (内部待機) | WARN ログのみ、provider に return |

Hyper-V の通常挙動では Resize は同期完了 (rv=0) が多いため、現状は同期成功のみ素通し。非同期開始は WARN ログのみで待機しない (**Job 完了待ちヘルパーは別 PR で実装予定**)。実用で問題化したら追加対応。

## CIM 制約

実装コメントに明記:
- Fixed VHD: 拡大のみ可 (縮小不可)
- Dynamic/Differencing: `MaxInternalSize` の縮小も可 (実データ末尾まで)
- VM へアタッチ中: オフライン状態のみ縮小可

## 検証

- `TestClientConfig_ResizeVhd_DefinedInWsmanPackage` 追加 (シャドウイング確認)
- `TestClientConfig_ImplementsHypervVhdClient` を更新 (ResizeVhd を shadow 側へ移動)
- `go test -race ./api/hyperv-wsman/... -count=1`: pass
- `go vet ./...` / `go build ./...`: クリーン
- 実機 acc test (homelab、`HYPERV_USE_WSMAN=1`) は別途

## Phase B-X 残

| Step | 内容 | go-wsman 側 |
|---|---|---|
| B-X.3 | CreateOrUpdateVhd | CIM 経由 (source コピーは別途) |
| B-X.4 | DeleteVhd | 案 D = WinRM 薄ラッパー (ファイル操作) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)