### PR TITLE
feat: CreateOrUpdateVhd を go-wsman 経由に移行 (Phase B-X.3)

### DIFF
--- a/api/hyperv-wsman/vhd.go
+++ b/api/hyperv-wsman/vhd.go
@@ -71,6 +71,24 @@ func vhdFormatFromPath(path string) uint16 {
 	}
 }
 
+// vhdDiskType は api.VhdType を CIM の DiskType (uint16) に安全に変換する。
+//
+// 直接 uint16(vhdType) すると、vhdType が provider 上流で strconv.Atoi 由来
+// (アーキ依存幅 int) のため CodeQL が上限チェックなしの縮小変換 (high) として検出する。
+// 既知 enum を switch で明示マッピングし、不明値は 0 (Unknown) にフォールバックする。
+func vhdDiskType(t api.VhdType) uint16 {
+	switch t {
+	case api.VhdType_Fixed:
+		return 2
+	case api.VhdType_Dynamic:
+		return 3
+	case api.VhdType_Differencing:
+		return 4
+	default:
+		return 0 // Unknown
+	}
+}
+
 // CreateOrUpdateVhd は go-wsman 経由で VHD/VHDX を作成または更新する。
 //
 // PowerShell 版 (hyperv_winrm.CreateOrUpdateVhd) の挙動を分岐ごとに再現:
@@ -101,9 +119,12 @@ func (c *ClientConfig) CreateOrUpdateVhd(ctx context.Context, path string, sourc
 	}
 
 	// 新規作成。DiskFormat は拡張子から導出、DiskType は vhdType (parentPath 指定時は差分)。
-	diskType := uint16(vhdType)
+	// vhdType は provider 上流で strconv.Atoi 由来 (アーキ依存幅 int) のため、直接
+	// uint16(vhdType) すると CodeQL go/incorrect-integer-conversion (上限チェックなし
+	// 縮小変換) を high 検出する。既知 enum のみ switch で安全に uint16 化する。
+	diskType := vhdDiskType(vhdType)
 	if parentPath != "" {
-		diskType = uint16(api.VhdType_Differencing)
+		diskType = vhdDiskType(api.VhdType_Differencing)
 	}
 
 	jobRef, err := c.WsmanClient.CreateVirtualHardDisk(ctx, &hyperv.Msvm_VirtualHardDiskSettingData{

--- a/api/hyperv-wsman/vhd.go
+++ b/api/hyperv-wsman/vhd.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
+	"github.com/r4sd/go-wsman/hyperv"
 	"github.com/taliesins/terraform-provider-hyperv/api"
 )
 
@@ -47,6 +49,75 @@ func (c *ClientConfig) ResizeVhd(ctx context.Context, path string, size uint64) 
 		// 現状は Job 完了待ちヘルパー未実装のため WARN ログのみ。
 		// 実用上は Resize は同期完了が多いためレアケース。問題化したら別 PR で実装。
 		log.Printf("[WARN][hyperv-wsman] ResizeVhd started asynchronously (jobRef=%s), not waiting for completion. Path=%q Size=%d", jobRef, path, size)
+	}
+	return nil
+}
+
+// vhdFormatFromPath はファイル拡張子から CIM の DiskFormat 値を導出する。
+//
+// PowerShell の New-VHD は拡張子からフォーマットを推論するが、CIM の
+// CreateVirtualHardDisk は明示的な Format (2=VHD, 3=VHDX, 4=VHDSet) を要求する。
+// 拡張子で判定し、不明な場合は modern default の VHDX を返す。
+func vhdFormatFromPath(path string) uint16 {
+	switch {
+	case strings.HasSuffix(strings.ToLower(path), ".vhdx"):
+		return uint16(api.VhdFormat_VHDX)
+	case strings.HasSuffix(strings.ToLower(path), ".vhds"):
+		return uint16(api.VhdFormat_VHDSet)
+	case strings.HasSuffix(strings.ToLower(path), ".vhd"):
+		return uint16(api.VhdFormat_VHD)
+	default:
+		return uint16(api.VhdFormat_VHDX)
+	}
+}
+
+// CreateOrUpdateVhd は go-wsman 経由で VHD/VHDX を作成または更新する。
+//
+// PowerShell 版 (hyperv_winrm.CreateOrUpdateVhd) の挙動を分岐ごとに再現:
+//   - source 指定 (ファイルコピー) / sourceVm 指定 (VM ディスクキャプチャ):
+//     CIM の範囲外 (ファイル操作・Convert-VHD) のため、埋め込みの PowerShell 実装に
+//     フォールバックする (戦略確定: 案 D)。
+//   - 既存 VHD あり: サイズ差があれば Resize、なければ no-op。
+//   - 新規作成 (通常 / 差分ディスク): Msvm_ImageManagementService.CreateVirtualHardDisk。
+//
+// 非同期 Job (ReturnValue=4096) は現状 WARN ログのみで待機しない (Resize と同様)。
+func (c *ClientConfig) CreateOrUpdateVhd(ctx context.Context, path string, source string, sourceVm string, sourceDisk int, vhdType api.VhdType, parentPath string, size uint64, blockSize uint32, logicalSectorSize uint32, physicalSectorSize uint32) error {
+	// 案 D: source コピー / VM ディスクキャプチャは CIM 範囲外 → PowerShell 経路へ委譲。
+	if source != "" || sourceVm != "" {
+		log.Printf("[DEBUG][hyperv-wsman] CreateOrUpdateVhd: source/sourceVm 指定のため PowerShell 経路にフォールバック (Path=%q)", path)
+		return c.ClientConfig.CreateOrUpdateVhd(ctx, path, source, sourceVm, sourceDisk, vhdType, parentPath, size, blockSize, logicalSectorSize, physicalSectorSize)
+	}
+
+	// 既存チェック: あればサイズ更新のみ (PowerShell の path-exists 分岐に対応)。
+	// GetVirtualHardDisk が成功 = 既存あり。エラーは「不在」扱い (VhdExists と同セマンティクス)。
+	if existing, err := c.WsmanClient.GetVirtualHardDisk(ctx, path); err == nil && existing != nil {
+		if size > 0 && existing.MaxInternalSize != size {
+			return c.ResizeVhd(ctx, path, size)
+		}
+		return nil
+	}
+
+	// 新規作成。DiskFormat は拡張子から導出、DiskType は vhdType (parentPath 指定時は差分)。
+	diskType := uint16(vhdType)
+	if parentPath != "" {
+		diskType = uint16(api.VhdType_Differencing)
+	}
+
+	jobRef, err := c.WsmanClient.CreateVirtualHardDisk(ctx, &hyperv.Msvm_VirtualHardDiskSettingData{
+		Path:               path,
+		ParentPath:         parentPath,
+		MaxInternalSize:    size,
+		BlockSize:          blockSize,
+		LogicalSectorSize:  logicalSectorSize,
+		PhysicalSectorSize: physicalSectorSize,
+		VirtualDiskFormat:  vhdFormatFromPath(path),
+		VirtualDiskType:    diskType,
+	})
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateOrUpdateVhd %q: %w", path, err)
+	}
+	if jobRef != "" {
+		log.Printf("[WARN][hyperv-wsman] CreateOrUpdateVhd started asynchronously (jobRef=%s), not waiting for completion. Path=%q", jobRef, path)
 	}
 	return nil
 }

--- a/api/hyperv-wsman/vhd.go
+++ b/api/hyperv-wsman/vhd.go
@@ -84,7 +84,10 @@ func vhdFormatFromPath(path string) uint16 {
 func (c *ClientConfig) CreateOrUpdateVhd(ctx context.Context, path string, source string, sourceVm string, sourceDisk int, vhdType api.VhdType, parentPath string, size uint64, blockSize uint32, logicalSectorSize uint32, physicalSectorSize uint32) error {
 	// 案 D: source コピー / VM ディスクキャプチャは CIM 範囲外 → PowerShell 経路へ委譲。
 	if source != "" || sourceVm != "" {
-		log.Printf("[DEBUG][hyperv-wsman] CreateOrUpdateVhd: source/sourceVm 指定のため PowerShell 経路にフォールバック (Path=%q)", path)
+		// 注意: 本関数は source (URL 形式で認証情報を埋め込める) を扱うため、
+		// CodeQL go/clear-text-logging が caller 由来の値のログ出力を secret 漏洩として
+		// 検出する。caller 由来の path は出さない。
+		log.Printf("[DEBUG][hyperv-wsman] CreateOrUpdateVhd: source/sourceVm 指定のため PowerShell 経路にフォールバック")
 		return c.ClientConfig.CreateOrUpdateVhd(ctx, path, source, sourceVm, sourceDisk, vhdType, parentPath, size, blockSize, logicalSectorSize, physicalSectorSize)
 	}
 
@@ -117,7 +120,8 @@ func (c *ClientConfig) CreateOrUpdateVhd(ctx context.Context, path string, sourc
 		return fmt.Errorf("hyperv-wsman: CreateOrUpdateVhd %q: %w", path, err)
 	}
 	if jobRef != "" {
-		log.Printf("[WARN][hyperv-wsman] CreateOrUpdateVhd started asynchronously (jobRef=%s), not waiting for completion. Path=%q", jobRef, path)
+		// caller 由来の path は出さず、サーバー生成の jobRef のみログする (clear-text-logging 対策)。
+		log.Printf("[WARN][hyperv-wsman] CreateOrUpdateVhd started asynchronously (jobRef=%s), not waiting for completion.", jobRef)
 	}
 	return nil
 }

--- a/api/hyperv-wsman/vhd_test.go
+++ b/api/hyperv-wsman/vhd_test.go
@@ -115,6 +115,31 @@ func TestClientConfig_CreateOrUpdateVhd_DefinedInWsmanPackage(t *testing.T) {
 	}
 }
 
+// TestVhdDiskType は api.VhdType → CIM DiskType (uint16) の安全マッピングを検証する。
+//
+// 直接 uint16 変換 (CodeQL go/incorrect-integer-conversion) を避けるための switch
+// マッピングが正しい CIM 値を返すことを保証する (データ変換ロジック = 必須テスト対象)。
+func TestVhdDiskType(t *testing.T) {
+	tests := []struct {
+		name string
+		in   api.VhdType
+		want uint16
+	}{
+		{"Fixed", api.VhdType_Fixed, 2},
+		{"Dynamic", api.VhdType_Dynamic, 3},
+		{"Differencing", api.VhdType_Differencing, 4},
+		{"Unknown", api.VhdType_Unknown, 0},
+		{"範囲外 → Unknown(0)", api.VhdType(9999), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vhdDiskType(tt.in); got != tt.want {
+				t.Errorf("vhdDiskType(%v) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestVhdFormatFromPath は拡張子から CIM DiskFormat 値への変換ロジックを検証する。
 //
 // PowerShell の New-VHD は拡張子推論するが CIM は明示 Format を要求するため、

--- a/api/hyperv-wsman/vhd_test.go
+++ b/api/hyperv-wsman/vhd_test.go
@@ -94,3 +94,50 @@ func TestClientConfig_ResizeVhd_DefinedInWsmanPackage(t *testing.T) {
 		t.Errorf("ResizeVhd signature mismatch: NumOut=%d, want 1", method.Type.NumOut())
 	}
 }
+
+// TestClientConfig_CreateOrUpdateVhd_DefinedInWsmanPackage は CreateOrUpdateVhd が
+// hyperv-wsman パッケージ自身で定義されていることを reflect 経由で検証する (Phase B-X.3)。
+func TestClientConfig_CreateOrUpdateVhd_DefinedInWsmanPackage(t *testing.T) {
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	method, ok := cType.MethodByName("CreateOrUpdateVhd")
+	if !ok {
+		t.Fatal("ClientConfig should have CreateOrUpdateVhd method")
+	}
+
+	// シグネチャ: (c *ClientConfig).CreateOrUpdateVhd(ctx, path, source, sourceVm,
+	//   sourceDisk, vhdType, parentPath, size, blockSize, logicalSectorSize,
+	//   physicalSectorSize) error
+	if method.Type.NumIn() != 12 { // receiver + 11 引数
+		t.Errorf("CreateOrUpdateVhd signature mismatch: NumIn=%d, want 12", method.Type.NumIn())
+	}
+	if method.Type.NumOut() != 1 { // error
+		t.Errorf("CreateOrUpdateVhd signature mismatch: NumOut=%d, want 1", method.Type.NumOut())
+	}
+}
+
+// TestVhdFormatFromPath は拡張子から CIM DiskFormat 値への変換ロジックを検証する。
+//
+// PowerShell の New-VHD は拡張子推論するが CIM は明示 Format を要求するため、
+// この変換が VHD/VHDX 作成の正しさを左右する (データ変換ロジック = 必須テスト対象)。
+func TestVhdFormatFromPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want uint16
+	}{
+		{"vhdx 小文字", `C:\vms\disk.vhdx`, uint16(api.VhdFormat_VHDX)},
+		{"vhdx 大文字混在", `C:\VMs\Disk.VHDX`, uint16(api.VhdFormat_VHDX)},
+		{"vhd 小文字", `C:\vms\disk.vhd`, uint16(api.VhdFormat_VHD)},
+		{"vhd 大文字", `C:\vms\DISK.VHD`, uint16(api.VhdFormat_VHD)},
+		{"vhds (VHDSet)", `C:\vms\disk.vhds`, uint16(api.VhdFormat_VHDSet)},
+		{"拡張子なし → VHDX default", `C:\vms\disk`, uint16(api.VhdFormat_VHDX)},
+		{"空文字 → VHDX default", "", uint16(api.VhdFormat_VHDX)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := vhdFormatFromPath(tt.path); got != tt.want {
+				t.Errorf("vhdFormatFromPath(%q) = %d, want %d", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

VHD 残メソッド 3 件目。`Msvm_ImageManagementService.CreateVirtualHardDisk` (CIM) を呼ぶシャドウイング実装。これで VHD CRUD のうち Get/Resize/Create が go-wsman 経由に。残るは Delete (#44) のみ。

## PowerShell 版の分岐再現

| 分岐 | 条件 | 実装 |
|---|---|---|
| ファイルコピー | `source != ""` | **PowerShell へフォールバック** (案D、ファイル操作は CIM 範囲外) |
| VM ディスクキャプチャ | `sourceVm != ""` | **PowerShell へフォールバック** (Convert-VHD) |
| 既存あり + サイズ差 | path 存在 & size 変化 | `ResizeVhd` 再利用 |
| 既存あり + 同サイズ | path 存在 & size 同一 | no-op |
| 新規作成 (通常/差分) | path 不在 | `CreateVirtualHardDisk` |

## CIM 固有の対応

### DiskFormat の導出
PowerShell の `New-VHD` は拡張子からフォーマットを推論するが、CIM の `CreateVirtualHardDisk` は明示的な Format 値を要求する。`vhdFormatFromPath` で拡張子から導出:

| 拡張子 | Format |
|---|---|
| `.vhdx` | 3 (VHDX) |
| `.vhd` | 2 (VHD) |
| `.vhds` | 4 (VHDSet) |
| 不明 | 3 (VHDX、modern default) |

### DiskType
`vhdType` (Fixed=2/Dynamic=3/Differencing=4) をそのまま使用。`parentPath` 指定時は Differencing に強制 (PowerShell の差分ディスク分岐と一致)。

### 非同期 Job
`ReturnValue=4096` は WARN ログのみで待機しない (Resize と同方針、Job 完了待ちヘルパーは別 PR)。

## 検証

- `TestVhdFormatFromPath`: 拡張子→Format 変換の table-driven test (7 ケース、大文字小文字・拡張子なし・空文字含む)
- `TestClientConfig_CreateOrUpdateVhd_DefinedInWsmanPackage`: シャドウイング確認
- `TestClientConfig_ImplementsHypervVhdClient`: 更新 (shadow 4 メソッド / promotion 1 メソッド)
- `go test -race ./api/hyperv-wsman/... -count=1`: pass
- `go vet ./...` / `go build ./...`: クリーン
- 実機 acc test (homelab、`HYPERV_USE_WSMAN=1`) は別途

## Phase B-X 残

| Step | 内容 | go-wsman 側 |
|---|---|---|
| B-X.4 (#44) | DeleteVhd | 案 D = WinRM 薄ラッパー (差分ディスク含むファイル削除) |

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)