### PR TITLE
fix: GitHub Actions ワークフローに最小権限の permissions を明示

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,6 +7,10 @@ env:
   GIT_CHGLOG_VERSION: "0.15.4"
   SVU_VERSION: "1.12.0"
 
+# CHANGELOG コミット + タグ作成のため書き込みが必要。
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -6,6 +6,10 @@ on:
       - edited
       - synchronize
 
+# PR タイトルの読み取りのみ。pull_request_target なので最小権限に絞る。
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ env:
   TEST_TIME_OUT: "120s"
   RELEASE_TIME_OUT: "30m"
 
+# 既定は最小権限 (読み取りのみ)。書き込みが要る goreleaser ジョブで個別に昇格する。
+permissions:
+  contents: read
+
 jobs:
   go_mod_download:
     name: go mod download
@@ -299,6 +303,9 @@ jobs:
   goreleaser:
     needs: [go_build]
     runs-on: ubuntu-latest
+    # リリース成果物のアップロード + CHANGELOG コミットのため書き込みが必要。
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
CodeQL (`actions/missing-workflow-permissions`, medium) が permissions ブロック未定義のワークフローを 9 件検出していたため、各ワークフローに最小権限を明示し GITHUB_TOKEN を既定の広い権限から絞る。

| ワークフロー | 権限 | 理由 |
|---|---|---|
| `release.yml` | top-level `contents: read` + `goreleaser` ジョブのみ `contents: write` | 読取系 6 ジョブは read、リリース成果物アップロード + CHANGELOG コミットを行う goreleaser のみ write |
| `create-release.yml` | `contents: write` | CHANGELOG コミット + タグ作成 |
| `lint-pr-title.yml` | `pull-requests: read` | PR タイトル読取のみ。`pull_request_target` トリガーのため特に最小化 |

## 検出アラート (解消対象)
- create-release.yml:12 / lint-pr-title.yml:11 / release.yml の 7 ジョブ (33,58,110,156,204,244,300)

## Test plan
- [x] `actionlint` で 3 ワークフロー検証 (新規エラーなし。既存の shellcheck info/style のみ)
- [x] YAML 構文確認
- [ ] マージ後 CodeQL 再スキャンで該当 9 アラートが解消されること