### PR TITLE
feat: VmExists + GetVm を go-wsman 経由に (Phase C-1.1)

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -1,0 +1,107 @@
+package hyperv_wsman
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// VmExists は go-wsman 経由で VM (表示名) の存在を確認する。
+//
+// FindComputerSystemByElementName が ErrVMNotFound を返した場合のみ「不在」とし、
+// それ以外のエラー (通信失敗等) は伝播させる。PowerShell 版は全エラーを不在扱いに
+// していたが、リゾルバの sentinel error により「不在」と「障害」を区別できる。
+func (c *ClientConfig) VmExists(ctx context.Context, name string) (api.VmExists, error) {
+	_, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name)
+	if err != nil {
+		if errors.Is(err, hyperv.ErrVMNotFound) {
+			return api.VmExists{Exists: false}, nil
+		}
+		return api.VmExists{}, fmt.Errorf("hyperv-wsman: VmExists %q: %w", name, err)
+	}
+	return api.VmExists{Exists: true}, nil
+}
+
+// GetVm は go-wsman 経由で VM の構成情報を取得する。
+//
+// 表示名→GUID を解決し、Realized の Msvm_VirtualSystemSettingData を取得して api.Vm に
+// マッピングする。VM レベルの設定 (世代・自動アクション・Notes 等) のみを対象とし、
+// Memory/CPU は別途 Msvm_MemorySettingData / Msvm_ProcessorSettingData が必要なため
+// 本メソッドでは設定しない (vmFromSettingData の注記参照)。
+func (c *ClientConfig) GetVm(ctx context.Context, name string) (api.Vm, error) {
+	cs, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name)
+	if err != nil {
+		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
+	}
+	sd, err := c.WsmanClient.GetSystemSettingData(ctx, cs.Name)
+	if err != nil {
+		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
+	}
+	return vmFromSettingData(name, sd), nil
+}
+
+// vmFromSettingData は Msvm_VirtualSystemSettingData を api.Vm にマッピングする (純関数)。
+//
+// enum (CriticalErrorAction/StartAction/StopAction) は provider 側の整数値が CIM 値と
+// 一致するよう定義されているため直接変換する (None=0/Pause=1、Nothing=2/Start=4 等)。
+// uint16→int は拡大変換のため安全。
+func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) api.Vm {
+	return api.Vm{
+		Name:                         name,
+		Path:                         sd.ConfigurationDataRoot,
+		Generation:                   vmGenerationFromSubType(sd.VirtualSystemSubType),
+		AutomaticCriticalErrorAction: api.CriticalErrorAction(sd.AutomaticCriticalErrorAction),
+		AutomaticStartAction:         api.StartAction(sd.AutomaticStartupAction),
+		AutomaticStopAction:          api.StopAction(sd.AutomaticShutdownAction),
+		Notes:                        strings.Join(sd.Notes, "\n"),
+		LockOnDisconnect:             lockOnDisconnectState(sd.LockOnDisconnect),
+		GuestControlledCacheTypes:    sd.GuestControlledCacheTypes,
+		HighMemoryMappedIoSpace:      sd.HighMmioGapSize,
+		LowMemoryMappedIoSpace:       clampUint32(sd.LowMmioGapSize),
+		SnapshotFileLocation:         sd.SnapshotDataRoot,
+		SmartPagingFilePath:          sd.SwapFileDataRoot,
+
+		// 以下は本メソッドでは未設定 (ゼロ値):
+		//   - Memory/CPU (MemoryStartupBytes/Min/Max, DynamicMemory, StaticMemory,
+		//     ProcessorCount): Msvm_MemorySettingData / Msvm_ProcessorSettingData が
+		//     別途必要 (CreateVm/C-2 で対応)。
+		//   - AutomaticStartDelay / AutomaticCriticalErrorActionTimeout: CIM の
+		//     Duration/interval 文字列パースが必要。実機が返す実書式に合わせるため
+		//     acc test (Phase D) で実データ確認後に実装する。
+		//   - CheckpointType / AutomaticCheckpointsEnabled: v2.1 (#46) に延期。
+	}
+}
+
+// vmGenerationFromSubType は VirtualSystemSubType を Generation 番号に変換する。
+func vmGenerationFromSubType(subType string) int {
+	switch subType {
+	case hyperv.VirtualSystemSubTypeGen1:
+		return 1
+	case hyperv.VirtualSystemSubTypeGen2:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// lockOnDisconnectState は CIM の bool を api.OnOffState に変換する。
+func lockOnDisconnectState(locked bool) api.OnOffState {
+	if locked {
+		return api.OnOffState_On
+	}
+	return api.OnOffState_Off
+}
+
+// clampUint32 は uint64 を uint32 に安全に縮小する (上限超過は MaxUint32 にクランプ)。
+// 直接 uint32(v) すると CodeQL が上限チェックなしの縮小変換 (high) として検出するため。
+func clampUint32(v uint64) uint32 {
+	if v > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v)
+}

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -1,0 +1,153 @@
+package hyperv_wsman
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// TestClientConfig_ImplementsHypervVmClient は ClientConfig が api.HypervVmClient を
+// 実装することを検証する。VmExists / GetVm は本パッケージで定義 (シャドウイング)、
+// CreateVm / UpdateVm / DeleteVm は hyperv-winrm から promotion される。
+func TestClientConfig_ImplementsHypervVmClient(t *testing.T) {
+	var c *ClientConfig
+	var _ api.HypervVmClient = c // コンパイル時チェック
+
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	for _, methodName := range []string{
+		"VmExists", // ← 本パッケージで定義 (シャドウイング、C-1.1)
+		"GetVm",    // ← 本パッケージで定義 (シャドウイング、C-1.1)
+		"CreateVm", // ← promotion (C-1.2 で移行予定)
+		"UpdateVm", // ← promotion (C-1.3 で移行予定)
+		"DeleteVm", // ← promotion (C-1.4 で移行予定)
+	} {
+		if _, ok := cType.MethodByName(methodName); !ok {
+			t.Errorf("ClientConfig should expose method %s (via shadow or promotion)", methodName)
+		}
+	}
+}
+
+// TestVmExists_DefinedInWsmanPackage は VmExists が本パッケージで定義されている
+// (= シャドウイングが効く) ことをシグネチャで確認する。
+func TestVmExists_DefinedInWsmanPackage(t *testing.T) {
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	method, ok := cType.MethodByName("VmExists")
+	if !ok {
+		t.Fatal("ClientConfig should have VmExists method")
+	}
+	if method.Type.NumIn() != 3 { // receiver + ctx + name
+		t.Errorf("VmExists: NumIn = %d, want 3", method.Type.NumIn())
+	}
+}
+
+// TestVmGenerationFromSubType は VirtualSystemSubType から Generation 番号への変換を検証する。
+func TestVmGenerationFromSubType(t *testing.T) {
+	tests := []struct {
+		subType string
+		want    int
+	}{
+		{hyperv.VirtualSystemSubTypeGen1, 1},
+		{hyperv.VirtualSystemSubTypeGen2, 2},
+		{"", 0},
+		{"Microsoft:Hyper-V:SubType:99", 0},
+	}
+	for _, tt := range tests {
+		if got := vmGenerationFromSubType(tt.subType); got != tt.want {
+			t.Errorf("vmGenerationFromSubType(%q) = %d, want %d", tt.subType, got, tt.want)
+		}
+	}
+}
+
+// TestLockOnDisconnectState は bool から api.OnOffState への変換を検証する。
+func TestLockOnDisconnectState(t *testing.T) {
+	if got := lockOnDisconnectState(true); got != api.OnOffState_On {
+		t.Errorf("lockOnDisconnectState(true) = %v, want On", got)
+	}
+	if got := lockOnDisconnectState(false); got != api.OnOffState_Off {
+		t.Errorf("lockOnDisconnectState(false) = %v, want Off", got)
+	}
+}
+
+// TestClampUint32 は uint64→uint32 の安全な縮小変換を検証する。
+func TestClampUint32(t *testing.T) {
+	tests := []struct {
+		in   uint64
+		want uint32
+	}{
+		{0, 0},
+		{128, 128},
+		{math.MaxUint32, math.MaxUint32},
+		{math.MaxUint32 + 1, math.MaxUint32}, // オーバーフローは上限でクランプ
+		{math.MaxUint64, math.MaxUint32},
+	}
+	for _, tt := range tests {
+		if got := clampUint32(tt.in); got != tt.want {
+			t.Errorf("clampUint32(%d) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestVmFromSettingData は Msvm_VirtualSystemSettingData → api.Vm マッピングの中核を検証する。
+//
+// enum は provider の整数値が CIM 値と一致するため直接変換される (Pause=1, Start=4, Save=3)。
+func TestVmFromSettingData(t *testing.T) {
+	sd := &hyperv.Msvm_VirtualSystemSettingData{
+		VirtualSystemSubType:         hyperv.VirtualSystemSubTypeGen2,
+		AutomaticCriticalErrorAction: 1, // Pause
+		AutomaticStartupAction:       4, // Start
+		AutomaticShutdownAction:      3, // Save
+		Notes:                        []string{"line1", "line2"},
+		LockOnDisconnect:             true,
+		GuestControlledCacheTypes:    true,
+		HighMmioGapSize:              512,
+		LowMmioGapSize:               128,
+		ConfigurationDataRoot:        `C:\vms\test`,
+		SnapshotDataRoot:             `C:\vms\snap`,
+		SwapFileDataRoot:             `C:\vms\swap`,
+	}
+
+	got := vmFromSettingData("test-vm", sd)
+
+	if got.Name != "test-vm" {
+		t.Errorf("Name = %q, want test-vm", got.Name)
+	}
+	if got.Generation != 2 {
+		t.Errorf("Generation = %d, want 2", got.Generation)
+	}
+	if got.AutomaticCriticalErrorAction != api.CriticalErrorAction_Pause {
+		t.Errorf("AutomaticCriticalErrorAction = %v, want Pause", got.AutomaticCriticalErrorAction)
+	}
+	if got.AutomaticStartAction != api.StartAction_Start {
+		t.Errorf("AutomaticStartAction = %v, want Start", got.AutomaticStartAction)
+	}
+	if got.AutomaticStopAction != api.StopAction_Save {
+		t.Errorf("AutomaticStopAction = %v, want Save", got.AutomaticStopAction)
+	}
+	if got.Notes != "line1\nline2" {
+		t.Errorf("Notes = %q, want line1\\nline2", got.Notes)
+	}
+	if got.LockOnDisconnect != api.OnOffState_On {
+		t.Errorf("LockOnDisconnect = %v, want On", got.LockOnDisconnect)
+	}
+	if !got.GuestControlledCacheTypes {
+		t.Error("GuestControlledCacheTypes = false, want true")
+	}
+	if got.HighMemoryMappedIoSpace != 512 {
+		t.Errorf("HighMemoryMappedIoSpace = %d, want 512", got.HighMemoryMappedIoSpace)
+	}
+	if got.LowMemoryMappedIoSpace != 128 {
+		t.Errorf("LowMemoryMappedIoSpace = %d, want 128", got.LowMemoryMappedIoSpace)
+	}
+	if got.Path != `C:\vms\test` {
+		t.Errorf("Path = %q", got.Path)
+	}
+	if got.SnapshotFileLocation != `C:\vms\snap` {
+		t.Errorf("SnapshotFileLocation = %q", got.SnapshotFileLocation)
+	}
+	if got.SmartPagingFilePath != `C:\vms\swap` {
+		t.Errorf("SmartPagingFilePath = %q", got.SmartPagingFilePath)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260528163136-fd43c067d8f4
+	github.com/r4sd/go-wsman v0.0.0-20260619042515-128628aed9b7
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260528163136-fd43c067d8f4 h1:0FAzh8o6nc6l/K4u/MX+OjL/pRk/PVJP5nXuPHTDwCM=
-github.com/r4sd/go-wsman v0.0.0-20260528163136-fd43c067d8f4/go.mod h1:uLiKo3lIZJe2MwVjBsjOTPzkTuWJFc4/gf7L1mVqOb8=
+github.com/r4sd/go-wsman v0.0.0-20260619042515-128628aed9b7 h1:Ni6Zv8HWrLC7oing10xLbBflH7FjYQkh0R86UY4iPbc=
+github.com/r4sd/go-wsman v0.0.0-20260619042515-128628aed9b7/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=


### PR DESCRIPTION
## 概要

`hyperv_machine_instance` の read 経路 (`VmExists` / `GetVm`) を go-wsman 経由のシャドウイングに移行する。Phase C-1 (#45) の最小リスク部分から着手。

## 変更内容

- **VmExists**: `FindComputerSystemByElementName` で表示名を解決。`ErrVMNotFound` のみ「不在」とし、通信障害等は伝播 (PowerShell 版の「全エラー=不在」より厳密)
- **GetVm**: 表示名→GUID 解決 → `GetSystemSettingData` → `api.Vm` にマッピング
  - enum (CriticalErrorAction/StartAction/StopAction) は **provider の整数値が CIM 値と一致するよう定義済み**のため直接変換 (uint16→int は拡大変換で安全)
  - `LowMmioGapSize` は `clampUint32` で安全に縮小 (CodeQL 縮小変換対策)
- go-wsman を bump (`FindComputerSystemByElementName` / `WaitForJob` 取り込み)

## スコープ外 (本メソッドでは未設定)

| 項目 | 理由 |
|------|------|
| Memory/CPU | `Msvm_MemorySettingData` / `Msvm_ProcessorSettingData` が別途必要 (C-1.2/C-2) |
| AutomaticStartDelay / CriticalErrorActionTimeout | CIM Duration/interval パースが必要。実機書式を確認してから (Phase D) |
| CheckpointType / AutomaticCheckpointsEnabled | v2.1 (#46) |

## テスト

- マッピング純関数 (`vmFromSettingData` / `vmGenerationFromSubType` / `lockOnDisconnectState` / `clampUint32`) を table-driven test
- シャドウイング (VmExists/GetVm が本パッケージ定義) を reflect で確認
- `go build` / `go test` / `go vet` 緑
- 実機 read 一致は acc test (Phase D) で検証

## 関連

親: #45 / 前提: go-wsman の FindComputerSystemByElementName・WaitForJob (マージ済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)