### PR TITLE
fix: lint-pr-title ワークフローに statuses:write を付与

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -6,9 +6,12 @@ on:
       - edited
       - synchronize
 
-# PR タイトルの読み取りのみ。pull_request_target なので最小権限に絞る。
+# PR タイトルの読み取り + WIP チェックのコミットステータス報告に必要な最小権限。
+# wip: true の場合、action は2つ目のチェックをコミットステータスとして報告するため
+# statuses: write が必須 (これが無いと "Resource not accessible by integration" で失敗)。
 permissions:
   pull-requests: read
+  statuses: write
 
 jobs:
   main:


### PR DESCRIPTION
## 概要

`Lint PR title` ワークフローの `main` ジョブが全 PR で `Resource not accessible by integration` により失敗していた問題を修正する。

## 原因

#50 の最小権限化以降、`permissions` が `pull-requests: read` のみになった。`amannn/action-semantic-pull-request` は `wip: true` 設定時に2つ目のチェックを**コミットステータス**として報告するため `statuses: write` が必須だが、それが無く権限不足で失敗していた (provider repo で #50 以降の初 PR で顕在化)。

## 修正

`permissions` に `statuses: write` を追加。WIP チェック機能を維持したまま解消する。

## 注意

`pull_request_target` は base ブランチ版のワークフローで実行されるため、**本 PR 自体の `main` チェックは旧版で動き赤のまま**。マージ後に全 PR で有効化される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)