### PR TITLE
feat: DeleteVm を go-wsman 経由に (C-1.4, #53)

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -105,3 +105,45 @@ func clampUint32(v uint64) uint32 {
 	}
 	return uint32(v)
 }
+
+// DeleteVm は go-wsman 経由で VM (表示名) を削除する。
+//
+// 表示名→GUID を解決し、起動中なら強制電源断 (TurnOff) してから DestroySystem を呼ぶ。
+// DestroySystem は Off 状態の VM でしか成功しないため、停止を先行させる必要がある。
+// 非同期 Job はそれぞれ WaitForJob で完了を待つ。VM が存在しない場合は冪等に nil を返す
+// (PowerShell 版の `Get-VM | Remove-VM` が空パイプでエラーにならない挙動と揃える)。
+func (c *ClientConfig) DeleteVm(ctx context.Context, name string) error {
+	cs, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name)
+	if err != nil {
+		if errors.Is(err, hyperv.ErrVMNotFound) {
+			return nil // 既に存在しない: 冪等に成功扱い
+		}
+		return fmt.Errorf("hyperv-wsman: DeleteVm %q: %w", name, err)
+	}
+	guid := cs.Name
+
+	if needsTurnOff(cs.EnabledState) {
+		jobRef, err := c.WsmanClient.TurnOffVM(ctx, guid)
+		if err != nil {
+			return fmt.Errorf("hyperv-wsman: DeleteVm %q: turn off: %w", name, err)
+		}
+		if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+			return fmt.Errorf("hyperv-wsman: DeleteVm %q: wait turn off: %w", name, err)
+		}
+	}
+
+	jobRef, err := c.WsmanClient.DestroySystem(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: DeleteVm %q: destroy: %w", name, err)
+	}
+	if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: DeleteVm %q: wait destroy: %w", name, err)
+	}
+	return nil
+}
+
+// needsTurnOff は EnabledState が「DestroySystem 前に停止が必要」な状態か判定する。
+// DestroySystem は Off 状態でしか成功しないため、Off(3) 以外は一律停止が必要とみなす。
+func needsTurnOff(state uint16) bool {
+	return state != hyperv.EnabledStateDisabled
+}

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // TestClientConfig_ImplementsHypervVmClient は ClientConfig が api.HypervVmClient を
-// 実装することを検証する。VmExists / GetVm は本パッケージで定義 (シャドウイング)、
-// CreateVm / UpdateVm / DeleteVm は hyperv-winrm から promotion される。
+// 実装することを検証する。VmExists / GetVm / DeleteVm は本パッケージで定義 (シャドウイング)、
+// CreateVm / UpdateVm は hyperv-winrm から promotion される。
 func TestClientConfig_ImplementsHypervVmClient(t *testing.T) {
 	var c *ClientConfig
 	var _ api.HypervVmClient = c // コンパイル時チェック
@@ -22,7 +22,7 @@ func TestClientConfig_ImplementsHypervVmClient(t *testing.T) {
 		"GetVm",    // ← 本パッケージで定義 (シャドウイング、C-1.1)
 		"CreateVm", // ← promotion (C-1.2 で移行予定)
 		"UpdateVm", // ← promotion (C-1.3 で移行予定)
-		"DeleteVm", // ← promotion (C-1.4 で移行予定)
+		"DeleteVm", // ← 本パッケージで定義 (シャドウイング、C-1.4)
 	} {
 		if _, ok := cType.MethodByName(methodName); !ok {
 			t.Errorf("ClientConfig should expose method %s (via shadow or promotion)", methodName)
@@ -149,5 +149,41 @@ func TestVmFromSettingData(t *testing.T) {
 	}
 	if got.SmartPagingFilePath != `C:\vms\swap` {
 		t.Errorf("SmartPagingFilePath = %q", got.SmartPagingFilePath)
+	}
+}
+
+// TestDeleteVm_DefinedInWsmanPackage は DeleteVm が本パッケージで定義されている
+// (= シャドウイングが効き、PowerShell 版を置き換える) ことをシグネチャで確認する。
+func TestDeleteVm_DefinedInWsmanPackage(t *testing.T) {
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	method, ok := cType.MethodByName("DeleteVm")
+	if !ok {
+		t.Fatal("ClientConfig should have DeleteVm method")
+	}
+	if method.Type.NumIn() != 3 { // receiver + ctx + name
+		t.Errorf("DeleteVm: NumIn = %d, want 3", method.Type.NumIn())
+	}
+}
+
+// TestNeedsTurnOff は EnabledState から「削除前に停止が必要か」の判定を検証する。
+//
+// DestroySystem は起動中 (= Off 以外) の VM では失敗するため、Off(3) 以外は
+// すべて停止が必要と判定する (Running/Paused/Saved/Unknown を一律カバー)。
+func TestNeedsTurnOff(t *testing.T) {
+	tests := []struct {
+		name  string
+		state uint16
+		want  bool
+	}{
+		{"Off は停止不要", hyperv.EnabledStateDisabled, false},
+		{"Running は停止必要", hyperv.EnabledStateEnabled, true},
+		{"Paused は停止必要", hyperv.EnabledStatePaused, true},
+		{"Saved は停止必要", hyperv.EnabledStateSaved, true},
+		{"Unknown は停止必要 (安全側)", hyperv.EnabledStateUnknown, true},
+	}
+	for _, tt := range tests {
+		if got := needsTurnOff(tt.state); got != tt.want {
+			t.Errorf("needsTurnOff(%d) [%s] = %v, want %v", tt.state, tt.name, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## 概要

`hyperv_machine_instance` の Delete を go-wsman (CIM/WS-Man) 経由に移行する (Phase C-1.4)。
PowerShell の `Remove-VM` を CIM の `DestroySystem` に置き換える。

## 変更内容

- `api/hyperv-wsman/vm.go`: `DeleteVm` をシャドウイングで定義 + 純関数 `needsTurnOff`
- `api/hyperv-wsman/vm_test.go`: `needsTurnOff` の table-driven test + シャドウイング確認

## 設計判断

- go-wsman の停止/破棄メソッドは全て VM GUID を取るため、先頭で表示名→GUID 解決
  (`FindComputerSystemByElementName`、既存 VmExists/GetVm と同型)
- `DestroySystem` は Off 状態でしか成功しないため、`EnabledState` が Off(3) 以外なら
  先に `TurnOffVM` で強制電源断 → `WaitForJob`。Running/Paused/Saved/Unknown を一律カバー
- `ErrVMNotFound` を吸収して冪等 (PS版 `Get-VM | Remove-VM` の空パイプ挙動と一致)
- 各非同期 Job は `WaitForJob` で完了を待つ (空 jobRef は no-op)

## 検証 (ローカル)

| ゲート | 結果 |
|---|---|
| `go test -race ./api/hyperv-wsman/` | ✅ ok |
| `go vet` / `gofmt -l` | ✅ クリーン |
| `go build ./...` | ✅ |
| `govulncheck ./...` | ✅ コード起因 0 |
| `golangci-lint` v2 (--no-config) | ✅ 0 issues |

フロー全体 (起動中/停止中の実削除) は実機 acc test (Phase D, homelab) で検証する。

Closes #53