### PR TITLE
chore: golangci-lint を v2 に移行 (#58)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,10 +281,13 @@ jobs:
         name: go mod download
         run: go mod download
         
-      - run: go get -d github.com/golangci/golangci-lint/cmd/golangci-lint
-      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint
-      - run: golangci-lint run
-        continue-on-error: true  # Fork contains pre-existing warnings
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+        with:
+          install-mode: goinstall
+          version: latest
+        # Fork 由来の既存警告 (55 件) があるため当面は非ブロッキング。
+        continue-on-error: true
 
   # semgrep:
   #   # Disabled: requires SEMGREP_APP_TOKEN for semgrep ci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,70 +1,64 @@
-issues:
-  exclude-rules:
-    - linters:
-        - gosimple
-      text: "S1039:"
-
-    # フォーク元コード・依存パッケージの非推奨API警告を抑制
-    - linters:
-        - staticcheck
-      text: "SA1019:"
-
-    - linters:
-        - unparam
-      text: "always receives"
-
-  max-per-linter: 0
-  max-same-issues: 0
-
+version: "2"
+run:
+  modules-download-mode: mod
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - depguard
-    #- dogsled
-    #- dupl
     - errcheck
-    - exportloopref
-    #- funlen
-    #- gochecknoinits #needed for document generation
     - goconst
     - gocritic
-    #- gocyclo
-    - gofmt
-    - goimports
-    #- gomnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
-    #- lll
     - misspell
     - nakedret
     - noctx
     - nolintlint
     - staticcheck
-    #- stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-
-linters-settings:
-  errcheck:
-    ignore: github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema:ForceNew|Set,fmt:.*,io:Close
-  depguard:
+  settings:
+    depguard:
+      rules:
+        logger:
+          deny:
+            - pkg: github.com/sirupsen/logrus
+              desc: logging is allowed only by logutils.Log
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      logger:
-        deny:
-          # logging is allowed only by logutils.Log,
-          # logrus is allowed to use only in logutils package.
-          - pkg: "github.com/sirupsen/logrus"
-            desc: logging is allowed only by logutils.Log
-
-run:
-  modules-download-mode: mod
-  timeout: 10m
-
-skip-dirs-use-default: true
+      - linters:
+          - staticcheck
+        text: 'S1039:'
+      - linters:
+          - staticcheck
+        text: 'SA1019:'
+      - linters:
+          - unparam
+        text: always receives
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## 概要

CI lint が実質ノーチェック状態だったため、golangci-lint を v2 に移行して実効化する。

## 背景

- `.golangci.yml` が v1 フォーマット。go.mod は `go 1.26.4` だが、golangci-lint v1 系は
  Go 1.24 ビルドが最終でバージョン不整合により起動拒否される
- `release.yml` は `go install .../cmd/golangci-lint`(v2 ではパスが変わり失敗)
- lint job は `continue-on-error: true` で全部素通り
- go-wsman 側は既に v2 (`golangci-lint-action@v9.2.1`)

## 変更内容

- `.golangci.yml`: `golangci-lint migrate` で v2 形式へ変換
  (gosimple/typecheck は staticcheck に統合、exportloopref 廃止、gofmt/goimports は formatters へ)
- `release.yml`: lint job を `golangci-lint-action@v9.2.1`(SHA pin)に置換、go-wsman と統一

## fork 由来の既存警告 (55 件)

v2 設定で全体 lint した結果すべて fork 既存コード由来 (goconst 50/staticcheck 3/unparam 1/gofmt 1)。
新規の `api/hyperv-wsman/` は 0 件。当面 `continue-on-error: true` で吸収する。

Closes #58