### PR TITLE
feat: CreateVm を go-wsman 経由に (C-1.2, #52)

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -147,3 +147,199 @@ func (c *ClientConfig) DeleteVm(ctx context.Context, name string) error {
 func needsTurnOff(state uint16) bool {
 	return state != hyperv.EnabledStateDisabled
 }
+
+// CreateVm は go-wsman 経由で新規 VM を作成する。
+//
+// PowerShell 版 (New-VM + Set-VM 群) を CIM 化する。冪等性のため事前に存在確認し、
+// DefineSystem で VM-level 設定込みの VM を作成 → Memory/Processor をリソース設定として
+// 適用する。各非同期 Job は WaitForJob で完了を待つ。
+//
+// go-wsman の DefineSystem は「リソースを持たない VM」を作る (PowerShell New-VM のような
+// 自動 NIC/DVD は付かない想定)。parity 担保のため自動生成 NIC は防御的に削除する
+// (実際に生成されるかは Phase D 実機で確認)。
+//
+// 未適用 (GetVm と同じ理由で将来対応):
+//   - automaticStartDelay / automaticCriticalErrorActionTimeout: CIM Duration 文字列の
+//     エンコードが要る。実機書式を Phase D で確認後に対応。
+//   - checkpointType / automaticCheckpointsEnabled: v2.1 (#46) に延期。
+func (c *ClientConfig) CreateVm(
+	ctx context.Context,
+	name string,
+	path string,
+	generation int,
+	automaticCriticalErrorAction api.CriticalErrorAction,
+	automaticCriticalErrorActionTimeout int32,
+	automaticStartAction api.StartAction,
+	automaticStartDelay int32,
+	automaticStopAction api.StopAction,
+	checkpointType api.CheckpointType,
+	dynamicMemory bool,
+	guestControlledCacheTypes bool,
+	highMemoryMappedIoSpace uint64,
+	lockOnDisconnect api.OnOffState,
+	lowMemoryMappedIoSpace uint32,
+	memoryMaximumBytes int64,
+	memoryMinimumBytes int64,
+	memoryStartupBytes int64,
+	notes string,
+	processorCount int64,
+	smartPagingFilePath string,
+	snapshotFileLocation string,
+	staticMemory bool,
+	automaticCheckpointsEnabled bool,
+) error {
+	// 1. 冪等性: 既存なら作成しない (PowerShell 版の throw "VM already exists" 相当)。
+	if _, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name); err == nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: VM already exists", name)
+	} else if !errors.Is(err, hyperv.ErrVMNotFound) {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: existence check: %w", name, err)
+	}
+
+	// 2. VM 本体を作成 (VM-level 設定込み)。
+	sd, err := vmSettingDataForCreate(name, path, generation,
+		automaticCriticalErrorAction, automaticStartAction, automaticStopAction,
+		guestControlledCacheTypes, highMemoryMappedIoSpace, lockOnDisconnect,
+		lowMemoryMappedIoSpace, notes, smartPagingFilePath, snapshotFileLocation)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: %w", name, err)
+	}
+	res, err := c.WsmanClient.DefineSystem(ctx, sd)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: define: %w", name, err)
+	}
+	if err := c.WsmanClient.WaitForJob(ctx, res.JobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: wait define: %w", name, err)
+	}
+	guid := res.ResultingSystem // Msvm_ComputerSystem.Name (以降のリソース操作は GUID で引く)
+
+	// 3. 自動生成 NIC があれば削除 (残すと後続 NIC Phase で state ドリフトする)。
+	adapters, err := c.WsmanClient.ListNetworkAdapters(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: list adapters: %w", name, err)
+	}
+	for _, a := range adapters {
+		jobRef, err := c.WsmanClient.RemoveNetworkAdapter(ctx, a.InstanceID)
+		if err != nil {
+			return fmt.Errorf("hyperv-wsman: CreateVm %q: remove adapter: %w", name, err)
+		}
+		if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+			return fmt.Errorf("hyperv-wsman: CreateVm %q: wait remove adapter: %w", name, err)
+		}
+	}
+
+	// 4. Memory: 既定設定を取得して上書き適用 (CIM は MB 単位)。
+	mem, err := c.WsmanClient.GetMemorySettings(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: get memory: %w", name, err)
+	}
+	applyMemorySettings(mem, staticMemory, dynamicMemory, memoryStartupBytes, memoryMinimumBytes, memoryMaximumBytes)
+	if jobRef, err := c.WsmanClient.SetMemorySettings(ctx, mem); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: set memory: %w", name, err)
+	} else if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: wait memory: %w", name, err)
+	}
+
+	// 5. Processor: vCPU 数を設定。
+	proc, err := c.WsmanClient.GetProcessorSettings(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: get processor: %w", name, err)
+	}
+	if processorCount > 0 {
+		proc.VirtualQuantity = uint64(processorCount)
+	}
+	if jobRef, err := c.WsmanClient.SetProcessorSettings(ctx, proc); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: set processor: %w", name, err)
+	} else if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVm %q: wait processor: %w", name, err)
+	}
+
+	return nil
+}
+
+// vmSubTypeFromGeneration は Generation 番号を CIM VirtualSystemSubType に変換する。
+func vmSubTypeFromGeneration(generation int) (string, error) {
+	switch generation {
+	case 1:
+		return hyperv.VirtualSystemSubTypeGen1, nil
+	case 2:
+		return hyperv.VirtualSystemSubTypeGen2, nil
+	default:
+		return "", fmt.Errorf("unsupported generation %d (1 か 2)", generation)
+	}
+}
+
+// enumToUint16 は provider enum (int) を CIM uint16 に安全変換する。
+// 範囲外は 0 (既定 = None/Nothing) に倒す。enum 値は 0-4 想定だが、直接 uint16() すると
+// gosec G115 が桁あふれ変換として検出するため (clampUint32 と同趣旨)。
+func enumToUint16(v int) uint16 {
+	if v < 0 || v > math.MaxUint16 {
+		return 0
+	}
+	return uint16(v)
+}
+
+// bytesToMB はバイトを MB に変換する (CIM の Memory/MMIO は MB 単位)。負値・端数は切り捨て。
+func bytesToMB(b int64) uint64 {
+	if b <= 0 {
+		return 0
+	}
+	return uint64(b) / (1024 * 1024)
+}
+
+// applyMemorySettings は static/dynamic に応じて Msvm_MemorySettingData を上書きする。
+//
+// VirtualQuantity は起動時メモリ(MB)。static は固定メモリ (Min/Max 無視)、dynamic は
+// Reservation=最小 / Limit=最大 を設定する。PowerShell 版の StaticMemory/DynamicMemory
+// 排他ロジックに対応。
+func applyMemorySettings(m *hyperv.Msvm_MemorySettingData, staticMemory, dynamicMemory bool, startupBytes, minBytes, maxBytes int64) {
+	m.VirtualQuantity = bytesToMB(startupBytes)
+	if staticMemory {
+		m.DynamicMemoryEnabled = false
+		return
+	}
+	m.DynamicMemoryEnabled = dynamicMemory
+	if dynamicMemory {
+		m.Reservation = bytesToMB(minBytes)
+		m.Limit = bytesToMB(maxBytes)
+	}
+}
+
+// vmSettingDataForCreate は CreateVm パラメータから DefineSystem 用の
+// Msvm_VirtualSystemSettingData を構築する (GetVm の vmFromSettingData の逆方向)。
+//
+// enum は provider 整数値が CIM 値と一致するため直接変換する (GetVm と同じ前提、MOF 突合済み)。
+// ゼロ値フィールドは marshalEmbeddedInstance が省略し CIM 既定になる。
+func vmSettingDataForCreate(
+	name, path string, generation int,
+	criticalErrorAction api.CriticalErrorAction,
+	startAction api.StartAction,
+	stopAction api.StopAction,
+	guestControlledCacheTypes bool,
+	highMmioGapSize uint64,
+	lockOnDisconnect api.OnOffState,
+	lowMmioGapSize uint32,
+	notes, smartPagingFilePath, snapshotFileLocation string,
+) (*hyperv.Msvm_VirtualSystemSettingData, error) {
+	subType, err := vmSubTypeFromGeneration(generation)
+	if err != nil {
+		return nil, err
+	}
+	sd := &hyperv.Msvm_VirtualSystemSettingData{
+		ElementName:                  name,
+		VirtualSystemSubType:         subType,
+		ConfigurationDataRoot:        path,
+		SnapshotDataRoot:             snapshotFileLocation,
+		SwapFileDataRoot:             smartPagingFilePath,
+		AutomaticStartupAction:       enumToUint16(int(startAction)),
+		AutomaticShutdownAction:      enumToUint16(int(stopAction)),
+		AutomaticCriticalErrorAction: enumToUint16(int(criticalErrorAction)),
+		LockOnDisconnect:             lockOnDisconnect == api.OnOffState_On,
+		GuestControlledCacheTypes:    guestControlledCacheTypes,
+		HighMmioGapSize:              highMmioGapSize,
+		LowMmioGapSize:               uint64(lowMmioGapSize),
+	}
+	if notes != "" {
+		sd.Notes = strings.Split(notes, "\n")
+	}
+	return sd, nil
+}

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -20,7 +20,7 @@ func TestClientConfig_ImplementsHypervVmClient(t *testing.T) {
 	for _, methodName := range []string{
 		"VmExists", // ← 本パッケージで定義 (シャドウイング、C-1.1)
 		"GetVm",    // ← 本パッケージで定義 (シャドウイング、C-1.1)
-		"CreateVm", // ← promotion (C-1.2 で移行予定)
+		"CreateVm", // ← 本パッケージで定義 (シャドウイング、C-1.2)
 		"UpdateVm", // ← promotion (C-1.3 で移行予定)
 		"DeleteVm", // ← 本パッケージで定義 (シャドウイング、C-1.4)
 	} {
@@ -185,5 +185,170 @@ func TestNeedsTurnOff(t *testing.T) {
 		if got := needsTurnOff(tt.state); got != tt.want {
 			t.Errorf("needsTurnOff(%d) [%s] = %v, want %v", tt.state, tt.name, got, tt.want)
 		}
+	}
+}
+
+// TestCreateVm_DefinedInWsmanPackage は CreateVm が本パッケージで定義されている
+// (= シャドウイングが効き、PowerShell 版を置き換える) ことを確認する。
+func TestCreateVm_DefinedInWsmanPackage(t *testing.T) {
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	if _, ok := cType.MethodByName("CreateVm"); !ok {
+		t.Fatal("ClientConfig should have CreateVm method")
+	}
+}
+
+// TestVmSubTypeFromGeneration は Generation 番号 → CIM VirtualSystemSubType 変換を検証する。
+func TestVmSubTypeFromGeneration(t *testing.T) {
+	tests := []struct {
+		gen     int
+		want    string
+		wantErr bool
+	}{
+		{1, hyperv.VirtualSystemSubTypeGen1, false},
+		{2, hyperv.VirtualSystemSubTypeGen2, false},
+		{0, "", true},
+		{3, "", true},
+	}
+	for _, tt := range tests {
+		got, err := vmSubTypeFromGeneration(tt.gen)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("vmSubTypeFromGeneration(%d) err=%v, wantErr=%v", tt.gen, err, tt.wantErr)
+		}
+		if got != tt.want {
+			t.Errorf("vmSubTypeFromGeneration(%d)=%q, want %q", tt.gen, got, tt.want)
+		}
+	}
+}
+
+// TestEnumToUint16 は provider enum(int)→CIM uint16 の安全変換を検証する。
+func TestEnumToUint16(t *testing.T) {
+	tests := []struct {
+		in   int
+		want uint16
+	}{
+		{0, 0},
+		{4, 4},
+		{-1, 0}, // 負値は 0
+		{math.MaxUint16, math.MaxUint16},
+		{math.MaxUint16 + 1, 0}, // 範囲外は 0
+	}
+	for _, tt := range tests {
+		if got := enumToUint16(tt.in); got != tt.want {
+			t.Errorf("enumToUint16(%d)=%d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestBytesToMB は バイト→MB 変換 (CIM Memory/MMIO は MB 単位) を検証する。
+func TestBytesToMB(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  uint64
+	}{
+		{0, 0},
+		{1048576, 1},       // 1 MiB
+		{2147483648, 2048}, // 2 GiB
+		{1048575, 0},       // 1 MiB 未満は切り捨て
+		{-1, 0},            // 負値は 0
+	}
+	for _, tt := range tests {
+		if got := bytesToMB(tt.bytes); got != tt.want {
+			t.Errorf("bytesToMB(%d)=%d, want %d", tt.bytes, got, tt.want)
+		}
+	}
+}
+
+// TestApplyMemorySettings は static/dynamic メモリ設定の適用を検証する。
+func TestApplyMemorySettings(t *testing.T) {
+	t.Run("static は固定メモリ・Min/Max無視", func(t *testing.T) {
+		m := &hyperv.Msvm_MemorySettingData{InstanceID: "x"}
+		applyMemorySettings(m, true, false, 2147483648, 1073741824, 4294967296)
+		if m.DynamicMemoryEnabled {
+			t.Error("static: DynamicMemoryEnabled は false であるべき")
+		}
+		if m.VirtualQuantity != 2048 {
+			t.Errorf("static: VirtualQuantity=%d, want 2048", m.VirtualQuantity)
+		}
+		if m.Reservation != 0 || m.Limit != 0 {
+			t.Errorf("static: Min/Max は未設定であるべき (Reservation=%d Limit=%d)", m.Reservation, m.Limit)
+		}
+	})
+	t.Run("dynamic は Reservation=Min / Limit=Max", func(t *testing.T) {
+		m := &hyperv.Msvm_MemorySettingData{InstanceID: "x"}
+		applyMemorySettings(m, false, true, 2147483648, 1073741824, 4294967296)
+		if !m.DynamicMemoryEnabled {
+			t.Error("dynamic: DynamicMemoryEnabled は true であるべき")
+		}
+		if m.VirtualQuantity != 2048 {
+			t.Errorf("dynamic: VirtualQuantity=%d, want 2048", m.VirtualQuantity)
+		}
+		if m.Reservation != 1024 {
+			t.Errorf("dynamic: Reservation=%d, want 1024", m.Reservation)
+		}
+		if m.Limit != 4096 {
+			t.Errorf("dynamic: Limit=%d, want 4096", m.Limit)
+		}
+	})
+}
+
+// TestVmSettingDataForCreate は CreateVm パラメータ → Msvm_VirtualSystemSettingData
+// マッピング (GetVm の vmFromSettingData の逆) を検証する。
+func TestVmSettingDataForCreate(t *testing.T) {
+	const (
+		cfgPath  = `C:\hyperv\create-test`
+		pagePath = `C:\hyperv\paging`
+		snapPath = `C:\hyperv\snap`
+	)
+	sd, err := vmSettingDataForCreate(
+		"vm1", cfgPath, 2,
+		api.CriticalErrorAction_Pause, api.StartAction_Start, api.StopAction_Save,
+		true, 512, api.OnOffState_On, 128,
+		"note1\nnote2", pagePath, snapPath,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sd.ElementName != "vm1" {
+		t.Errorf("ElementName=%q", sd.ElementName)
+	}
+	if sd.VirtualSystemSubType != hyperv.VirtualSystemSubTypeGen2 {
+		t.Errorf("VirtualSystemSubType=%q", sd.VirtualSystemSubType)
+	}
+	if sd.ConfigurationDataRoot != cfgPath {
+		t.Errorf("ConfigurationDataRoot=%q", sd.ConfigurationDataRoot)
+	}
+	if sd.AutomaticCriticalErrorAction != 1 { // Pause
+		t.Errorf("AutomaticCriticalErrorAction=%d, want 1", sd.AutomaticCriticalErrorAction)
+	}
+	if sd.AutomaticStartupAction != 4 { // Start
+		t.Errorf("AutomaticStartupAction=%d, want 4", sd.AutomaticStartupAction)
+	}
+	if sd.AutomaticShutdownAction != 3 { // Save
+		t.Errorf("AutomaticShutdownAction=%d, want 3", sd.AutomaticShutdownAction)
+	}
+	if !sd.LockOnDisconnect {
+		t.Error("LockOnDisconnect は true であるべき")
+	}
+	if !sd.GuestControlledCacheTypes {
+		t.Error("GuestControlledCacheTypes は true であるべき")
+	}
+	if sd.HighMmioGapSize != 512 {
+		t.Errorf("HighMmioGapSize=%d, want 512", sd.HighMmioGapSize)
+	}
+	if sd.LowMmioGapSize != 128 {
+		t.Errorf("LowMmioGapSize=%d, want 128", sd.LowMmioGapSize)
+	}
+	if sd.SnapshotDataRoot != snapPath {
+		t.Errorf("SnapshotDataRoot=%q", sd.SnapshotDataRoot)
+	}
+	if sd.SwapFileDataRoot != pagePath {
+		t.Errorf("SwapFileDataRoot=%q", sd.SwapFileDataRoot)
+	}
+	if len(sd.Notes) != 2 || sd.Notes[0] != "note1" || sd.Notes[1] != "note2" {
+		t.Errorf("Notes=%v, want [note1 note2]", sd.Notes)
+	}
+
+	if _, err := vmSettingDataForCreate("x", "", 9, 0, 0, 0, false, 0, api.OnOffState_Off, 0, "", "", ""); err == nil {
+		t.Error("generation=9 はエラーになるべき")
 	}
 }


### PR DESCRIPTION
## 概要

`hyperv_machine_instance` の Create を go-wsman (CIM/WS-Man) 経由に移行する (Phase C-1.2、本丸)。
PowerShell の `New-VM` + `Set-VM` 群を `DefineSystem` ベースのフローに置き換える。

## 変更内容

`api/hyperv-wsman/vm.go` に `CreateVm` をシャドウイングで定義。フロー:

1. 存在チェック (`FindComputerSystemByElementName`、既存なら error = PS 版 throw 相当)
2. `vmSettingDataForCreate` で `Msvm_VirtualSystemSettingData` 構築 → `DefineSystem` → `WaitForJob`
3. 自動生成 NIC を削除 (`ListNetworkAdapters` → `RemoveNetworkAdapter`、parity 担保)
4. Memory: `GetMemorySettings` → `applyMemorySettings` (MB 変換 / static・dynamic 排他) → `SetMemorySettings`
5. Processor: `GetProcessorSettings` → vCPU 数 → `SetProcessorSettings`

## 設計判断

- go-wsman の停止/破棄/リソース系は VM GUID で引くため、`DefineSystem` の `ResultingSystem` を使用
- enum (Start/Stop/CriticalError Action) は provider 整数値 = CIM 値で直接変換 (GetVm と同前提、MOF 突合済み)
- `enumToUint16` で gosec G115 (int→uint16 桁あふれ) を安全変換 (`clampUint32` と同趣旨)
- メモリは CIM が MB 単位 (`bytesToMB`)。static=固定 / dynamic=Reservation(最小)・Limit(最大)

## 未対応 (GetVm と同じ理由で後送り)

- `automaticStartDelay` / `automaticCriticalErrorActionTimeout`: CIM Duration 文字列エンコード → Phase D 実機書式確認後
- `checkpointType` / `automaticCheckpointsEnabled`: v2.1 (#46)

## 検証 (ローカル)

| ゲート | 結果 |
|---|---|
| `go test -race ./api/hyperv-wsman/` | ✅ ok |
| `go vet` / `gofmt -l` / `go build ./...` | ✅ クリーン |
| `govulncheck` | ✅ コード起因 0 |
| `golangci-lint` v2 | ✅ 新規コード 0 issues |

純関数 (`vmSubTypeFromGeneration` / `bytesToMB` / `applyMemorySettings` / `vmSettingDataForCreate` / `enumToUint16`) は table-driven test。フロー全体 (DefineSystem・自動生成 NIC/DVD の有無・メモリ反映) は実機 acc test (Phase D) で検証する。

Closes #52