### PR TITLE
feat: UpdateVm を go-wsman 経由に (C-1.3, #54)

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -256,6 +256,91 @@ func (c *ClientConfig) CreateVm(
 	return nil
 }
 
+// UpdateVm は go-wsman 経由で既存 VM の構成を更新する。
+//
+// 現構成を取得 → VM レベルの可変フィールドを書き換え → ModifySystemSettings (go-wsman の
+// UpdateVm) で反映 → Memory/Processor をリソース設定として更新する。各非同期 Job は
+// WaitForJob で待つ。path/generation は作成後に変更できないため対象外 (api 契約でも除外)。
+//
+// CIM の ModifySystemSettings はゼロ値フィールドを「変更なし」とみなすため、各フィールドは
+// 新しい値で上書きする (CreateVm と enum/メモリ変換ロジックを共有)。
+//
+// 未適用 (GetVm/CreateVm と同じ理由): automaticStartDelay /
+// automaticCriticalErrorActionTimeout (CIM Duration、Phase D) / checkpointType /
+// automaticCheckpointsEnabled (v2.1)。
+func (c *ClientConfig) UpdateVm(
+	ctx context.Context,
+	name string,
+	automaticCriticalErrorAction api.CriticalErrorAction,
+	automaticCriticalErrorActionTimeout int32,
+	automaticStartAction api.StartAction,
+	automaticStartDelay int32,
+	automaticStopAction api.StopAction,
+	checkpointType api.CheckpointType,
+	dynamicMemory bool,
+	guestControlledCacheTypes bool,
+	highMemoryMappedIoSpace uint64,
+	lockOnDisconnect api.OnOffState,
+	lowMemoryMappedIoSpace uint32,
+	memoryMaximumBytes int64,
+	memoryMinimumBytes int64,
+	memoryStartupBytes int64,
+	notes string,
+	processorCount int64,
+	smartPagingFilePath string,
+	snapshotFileLocation string,
+	staticMemory bool,
+	automaticCheckpointsEnabled bool,
+) error {
+	cs, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: %w", name, err)
+	}
+	guid := cs.Name
+
+	// 1. VM-level 設定: 現構成を取得 → 書き換え → ModifySystemSettings。
+	sd, err := c.WsmanClient.GetSystemSettingData(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: get settings: %w", name, err)
+	}
+	applyVmLevelSettings(sd, automaticCriticalErrorAction, automaticStartAction, automaticStopAction,
+		guestControlledCacheTypes, highMemoryMappedIoSpace, lockOnDisconnect, lowMemoryMappedIoSpace,
+		notes, smartPagingFilePath, snapshotFileLocation)
+	if jobRef, err := c.WsmanClient.UpdateVm(ctx, sd); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: modify settings: %w", name, err)
+	} else if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: wait modify: %w", name, err)
+	}
+
+	// 2. Memory。
+	mem, err := c.WsmanClient.GetMemorySettings(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: get memory: %w", name, err)
+	}
+	applyMemorySettings(mem, staticMemory, dynamicMemory, memoryStartupBytes, memoryMinimumBytes, memoryMaximumBytes)
+	if jobRef, err := c.WsmanClient.SetMemorySettings(ctx, mem); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: set memory: %w", name, err)
+	} else if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: wait memory: %w", name, err)
+	}
+
+	// 3. Processor。
+	proc, err := c.WsmanClient.GetProcessorSettings(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: get processor: %w", name, err)
+	}
+	if processorCount > 0 {
+		proc.VirtualQuantity = uint64(processorCount)
+	}
+	if jobRef, err := c.WsmanClient.SetProcessorSettings(ctx, proc); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: set processor: %w", name, err)
+	} else if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: wait processor: %w", name, err)
+	}
+
+	return nil
+}
+
 // vmSubTypeFromGeneration は Generation 番号を CIM VirtualSystemSubType に変換する。
 func vmSubTypeFromGeneration(generation int) (string, error) {
 	switch generation {
@@ -325,21 +410,46 @@ func vmSettingDataForCreate(
 		return nil, err
 	}
 	sd := &hyperv.Msvm_VirtualSystemSettingData{
-		ElementName:                  name,
-		VirtualSystemSubType:         subType,
-		ConfigurationDataRoot:        path,
-		SnapshotDataRoot:             snapshotFileLocation,
-		SwapFileDataRoot:             smartPagingFilePath,
-		AutomaticStartupAction:       enumToUint16(int(startAction)),
-		AutomaticShutdownAction:      enumToUint16(int(stopAction)),
-		AutomaticCriticalErrorAction: enumToUint16(int(criticalErrorAction)),
-		LockOnDisconnect:             lockOnDisconnect == api.OnOffState_On,
-		GuestControlledCacheTypes:    guestControlledCacheTypes,
-		HighMmioGapSize:              highMmioGapSize,
-		LowMmioGapSize:               uint64(lowMmioGapSize),
+		ElementName:           name,
+		VirtualSystemSubType:  subType,
+		ConfigurationDataRoot: path,
+	}
+	applyVmLevelSettings(sd, criticalErrorAction, startAction, stopAction,
+		guestControlledCacheTypes, highMmioGapSize, lockOnDisconnect, lowMmioGapSize,
+		notes, smartPagingFilePath, snapshotFileLocation)
+	return sd, nil
+}
+
+// applyVmLevelSettings は VM レベルの可変フィールドを settings に適用する (Create/Update 共有)。
+//
+// enum は provider 整数値 = CIM 値 (GetVm/CreateVm と同前提)。空文字のパスと未指定のゼロ値は
+// marshalEmbeddedInstance が省略するため、Update (ModifySystemSettings) では「未指定=変更なし」
+// になる (CIM SettingData の慣習)。InstanceID 等の既存値は呼び出し側が保持する。
+func applyVmLevelSettings(
+	sd *hyperv.Msvm_VirtualSystemSettingData,
+	criticalErrorAction api.CriticalErrorAction,
+	startAction api.StartAction,
+	stopAction api.StopAction,
+	guestControlledCacheTypes bool,
+	highMmioGapSize uint64,
+	lockOnDisconnect api.OnOffState,
+	lowMmioGapSize uint32,
+	notes, smartPagingFilePath, snapshotFileLocation string,
+) {
+	sd.AutomaticStartupAction = enumToUint16(int(startAction))
+	sd.AutomaticShutdownAction = enumToUint16(int(stopAction))
+	sd.AutomaticCriticalErrorAction = enumToUint16(int(criticalErrorAction))
+	sd.LockOnDisconnect = lockOnDisconnect == api.OnOffState_On
+	sd.GuestControlledCacheTypes = guestControlledCacheTypes
+	sd.HighMmioGapSize = highMmioGapSize
+	sd.LowMmioGapSize = uint64(lowMmioGapSize)
+	if snapshotFileLocation != "" {
+		sd.SnapshotDataRoot = snapshotFileLocation
+	}
+	if smartPagingFilePath != "" {
+		sd.SwapFileDataRoot = smartPagingFilePath
 	}
 	if notes != "" {
 		sd.Notes = strings.Split(notes, "\n")
 	}
-	return sd, nil
 }

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 // TestClientConfig_ImplementsHypervVmClient は ClientConfig が api.HypervVmClient を
-// 実装することを検証する。VmExists / GetVm / DeleteVm は本パッケージで定義 (シャドウイング)、
-// CreateVm / UpdateVm は hyperv-winrm から promotion される。
+// 実装することを検証する。Phase C-1 完了後は VM CRUD 全メソッドが本パッケージで定義
+// (シャドウイング) され、PowerShell 版を置き換える。
 func TestClientConfig_ImplementsHypervVmClient(t *testing.T) {
 	var c *ClientConfig
 	var _ api.HypervVmClient = c // コンパイル時チェック
@@ -21,7 +21,7 @@ func TestClientConfig_ImplementsHypervVmClient(t *testing.T) {
 		"VmExists", // ← 本パッケージで定義 (シャドウイング、C-1.1)
 		"GetVm",    // ← 本パッケージで定義 (シャドウイング、C-1.1)
 		"CreateVm", // ← 本パッケージで定義 (シャドウイング、C-1.2)
-		"UpdateVm", // ← promotion (C-1.3 で移行予定)
+		"UpdateVm", // ← 本パッケージで定義 (シャドウイング、C-1.3)
 		"DeleteVm", // ← 本パッケージで定義 (シャドウイング、C-1.4)
 	} {
 		if _, ok := cType.MethodByName(methodName); !ok {
@@ -350,5 +350,57 @@ func TestVmSettingDataForCreate(t *testing.T) {
 
 	if _, err := vmSettingDataForCreate("x", "", 9, 0, 0, 0, false, 0, api.OnOffState_Off, 0, "", "", ""); err == nil {
 		t.Error("generation=9 はエラーになるべき")
+	}
+}
+
+// TestUpdateVm_DefinedInWsmanPackage は UpdateVm が本パッケージで定義されている
+// (= シャドウイングが効き、PowerShell 版を置き換える) ことを確認する。
+func TestUpdateVm_DefinedInWsmanPackage(t *testing.T) {
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	if _, ok := cType.MethodByName("UpdateVm"); !ok {
+		t.Fatal("ClientConfig should have UpdateVm method")
+	}
+}
+
+// TestApplyVmLevelSettings は VM レベル可変フィールドの適用 (Create/Update 共有) を検証する。
+//
+// 既存 settings の InstanceID / SubType は保持し、可変フィールドのみ上書きすること。
+// 空文字のパスは「変更なし」として既存値を維持する (CIM ModifySystemSettings の慣習)。
+func TestApplyVmLevelSettings(t *testing.T) {
+	const existingSnap = `C:\existing\snap`
+	sd := &hyperv.Msvm_VirtualSystemSettingData{
+		InstanceID:           "keep-me",
+		VirtualSystemSubType: hyperv.VirtualSystemSubTypeGen2,
+		SnapshotDataRoot:     existingSnap,
+	}
+	applyVmLevelSettings(sd,
+		api.CriticalErrorAction_Pause, api.StartAction_Start, api.StopAction_Save,
+		true, 256, api.OnOffState_On, 64,
+		"n1\nn2", `C:\new\paging`, "") // snapshot="" → 既存維持
+
+	if sd.InstanceID != "keep-me" {
+		t.Errorf("InstanceID は保持されるべき: %q", sd.InstanceID)
+	}
+	if sd.VirtualSystemSubType != hyperv.VirtualSystemSubTypeGen2 {
+		t.Errorf("VirtualSystemSubType は保持されるべき: %q", sd.VirtualSystemSubType)
+	}
+	if sd.AutomaticStartupAction != 4 || sd.AutomaticShutdownAction != 3 || sd.AutomaticCriticalErrorAction != 1 {
+		t.Errorf("enum 適用ミス: start=%d stop=%d crit=%d",
+			sd.AutomaticStartupAction, sd.AutomaticShutdownAction, sd.AutomaticCriticalErrorAction)
+	}
+	if !sd.LockOnDisconnect || !sd.GuestControlledCacheTypes {
+		t.Error("bool フィールド適用ミス")
+	}
+	if sd.HighMmioGapSize != 256 || sd.LowMmioGapSize != 64 {
+		t.Errorf("MMIO 適用ミス: high=%d low=%d", sd.HighMmioGapSize, sd.LowMmioGapSize)
+	}
+	if sd.SwapFileDataRoot != `C:\new\paging` {
+		t.Errorf("SwapFileDataRoot=%q", sd.SwapFileDataRoot)
+	}
+	if sd.SnapshotDataRoot != existingSnap {
+		t.Errorf("snapshot 空文字なら既存維持のはず: %q", sd.SnapshotDataRoot)
+	}
+	if len(sd.Notes) != 2 || sd.Notes[0] != "n1" || sd.Notes[1] != "n2" {
+		t.Errorf("Notes=%v, want [n1 n2]", sd.Notes)
 	}
 }


### PR DESCRIPTION
## 概要

`hyperv_machine_instance` の Update を go-wsman (CIM/WS-Man) 経由に移行する (Phase C-1.3)。
PowerShell の `Set-VM` 群を `ModifySystemSettings` ベースのフローに置き換える。
**これで Phase C-1 の VM CRUD (read/Create/Update/Delete) が全て go-wsman 経由に揃う。**

## 変更内容

`api/hyperv-wsman/vm.go` に `UpdateVm` をシャドウイングで定義。フロー:

1. 表示名→GUID 解決 (`FindComputerSystemByElementName`)
2. `GetSystemSettingData` で現構成取得 → `applyVmLevelSettings` で可変フィールド書き換え → `UpdateVm`(ModifySystemSettings) → `WaitForJob`
3. Memory: `GetMemorySettings` → `applyMemorySettings` → `SetMemorySettings` → `WaitForJob`
4. Processor: `GetProcessorSettings` → vCPU 数 → `SetProcessorSettings` → `WaitForJob`

## 設計判断

- VM-level 設定の適用を CreateVm と共有する `applyVmLevelSettings` に切り出し (DRY、enum/メモリ変換も共有)
- `path` / `generation` は作成後に変更できないため対象外 (api 契約でもコメントアウト済み)
- CIM の `ModifySystemSettings` はゼロ値を「変更なし」とみなす → 各フィールドを新しい値で上書き。空文字パスは既存維持

## 未対応 (GetVm/CreateVm と同じ理由で後送り)

- `automaticStartDelay` / `automaticCriticalErrorActionTimeout`: CIM Duration → Phase D
- `checkpointType` / `automaticCheckpointsEnabled`: v2.1 (#46)

## 検証 (ローカル)

| ゲート | 結果 |
|---|---|
| `go test -race ./api/hyperv-wsman/` | ✅ ok |
| `go vet` / `gofmt -l` / `go build ./...` | ✅ クリーン |
| `govulncheck` | ✅ コード起因 0 |
| `golangci-lint` v2 | ✅ 新規コード 0 issues |

`applyVmLevelSettings` は table-driven test (InstanceID 保持・空パス維持・enum 適用を検証)。フロー全体は実機 acc test (Phase D) で検証する。

Closes #54