### PR TITLE
test: VM CRUD 実機統合テスト + UpdateVm 最小instance修正 (Phase D)

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -298,11 +298,15 @@ func (c *ClientConfig) UpdateVm(
 	}
 	guid := cs.Name
 
-	// 1. VM-level 設定: 現構成を取得 → 書き換え → ModifySystemSettings。
-	sd, err := c.WsmanClient.GetSystemSettingData(ctx, guid)
+	// 1. VM-level 設定: InstanceID を取得し、変更フィールドのみの最小 instance を
+	//    ModifySystemSettings に渡す。GetSystemSettingData の全体を送り返すと read-only
+	//    プロパティ (VirtualSystemType=Realized / CreationTime / BIOSGUID 等) でジョブが
+	//    Exception になるため (実機 acc test で確認、libvirt 実証の最小 instance パターン)。
+	cur, err := c.WsmanClient.GetSystemSettingData(ctx, guid)
 	if err != nil {
 		return fmt.Errorf("hyperv-wsman: UpdateVm %q: get settings: %w", name, err)
 	}
+	sd := &hyperv.Msvm_VirtualSystemSettingData{InstanceID: cur.InstanceID}
 	applyVmLevelSettings(sd, automaticCriticalErrorAction, automaticStartAction, automaticStopAction,
 		guestControlledCacheTypes, highMemoryMappedIoSpace, lockOnDisconnect, lowMemoryMappedIoSpace,
 		notes, smartPagingFilePath, snapshotFileLocation)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260619042515-128628aed9b7
+	github.com/r4sd/go-wsman v0.0.0-20260621112911-a6cc484373e0
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260619042515-128628aed9b7 h1:Ni6Zv8HWrLC7oing10xLbBflH7FjYQkh0R86UY4iPbc=
-github.com/r4sd/go-wsman v0.0.0-20260619042515-128628aed9b7/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260621112911-a6cc484373e0 h1:8SqbZxg7ZFrHbGv9Upeu3Rn/CUa8npMOIFHN2/5Sc2Q=
+github.com/r4sd/go-wsman v0.0.0-20260621112911-a6cc484373e0/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/vm_crud_integration_test.go
+++ b/internal/provider/vm_crud_integration_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の VM CRUD (Phase C-1) の実機統合テスト。
+//
+// 実 Hyper-V ホストに対して Create→Exists→Get→Update→Get→Delete→Exists の一周を回し、
+// CIM (DefineSystem / ModifySystemSettings / DestroySystem 等) 経路が PowerShell 版と
+// 同等に機能することを検証する。ユニットテストでは WsmanClient が具象型のため検証できない
+// オーケストレーション全体 (Phase D) を実機で確認するのが目的。
+//
+// integration タグ + 接続用環境変数が揃ったときのみ実行される (未設定なら Skip)。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	go test -tags integration ./internal/provider/ -run TestRealHostVmCrudWsman -v
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostVmCrudWsman(t *testing.T) {
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	// CRUD メソッドは WsmanClient のみ使う (winrm 埋め込みは不要)。
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	ctx := context.Background()
+
+	const (
+		name   = "tf-wsman-crud-test"
+		memByt = 536870912 // 512 MiB (起動時メモリ)
+	)
+
+	// 後始末: 失敗時も含めテスト VM を確実に削除 (DeleteVm は不在で冪等)。
+	t.Cleanup(func() {
+		if err := cc.DeleteVm(ctx, name); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+	// 前回の残骸があれば先に消す。
+	_ = cc.DeleteVm(ctx, name)
+
+	// --- 1. Create ---
+	if err := cc.CreateVm(ctx, name,
+		"",                            // path (既定の場所)
+		2,                             // generation (Gen2)
+		api.CriticalErrorAction_Pause, // automaticCriticalErrorAction
+		0,                             // automaticCriticalErrorActionTimeout
+		api.StartAction_Nothing,       // automaticStartAction
+		0,                             // automaticStartDelay
+		api.StopAction_Save,           // automaticStopAction
+		api.CheckpointType_Production, // checkpointType (未適用)
+		false,                         // dynamicMemory
+		false,                         // guestControlledCacheTypes
+		0,                             // highMemoryMappedIoSpace
+		api.OnOffState_Off,            // lockOnDisconnect
+		0,                             // lowMemoryMappedIoSpace
+		memByt,                        // memoryMaximumBytes
+		memByt,                        // memoryMinimumBytes
+		memByt,                        // memoryStartupBytes
+		"phase-d-create",              // notes
+		1,                             // processorCount
+		"",                            // smartPagingFilePath
+		"",                            // snapshotFileLocation
+		true,                          // staticMemory
+		false,                         // automaticCheckpointsEnabled
+	); err != nil {
+		t.Fatalf("CreateVm: %v", err)
+	}
+	t.Logf("CreateVm OK: %s", name)
+
+	// --- 2. Exists → true ---
+	ex, err := cc.VmExists(ctx, name)
+	if err != nil {
+		t.Fatalf("VmExists(after create): %v", err)
+	}
+	if !ex.Exists {
+		t.Fatal("VmExists after Create = false, want true")
+	}
+
+	// --- 3. Get → 構成検証 (Generation / Notes / enum) ---
+	vm, err := cc.GetVm(ctx, name)
+	if err != nil {
+		t.Fatalf("GetVm: %v", err)
+	}
+	if vm.Generation != 2 {
+		t.Errorf("Generation = %d, want 2", vm.Generation)
+	}
+	if vm.Notes != "phase-d-create" {
+		t.Errorf("Notes = %q, want phase-d-create", vm.Notes)
+	}
+	if vm.AutomaticStartAction != api.StartAction_Nothing {
+		t.Errorf("AutomaticStartAction = %v, want Nothing", vm.AutomaticStartAction)
+	}
+	t.Logf("GetVm OK: gen=%d notes=%q start=%v stop=%v crit=%v",
+		vm.Generation, vm.Notes, vm.AutomaticStartAction, vm.AutomaticStopAction, vm.AutomaticCriticalErrorAction)
+
+	// --- 4. Update → VM-level / Memory / Processor を変更 ---
+	if err := cc.UpdateVm(ctx, name,
+		api.CriticalErrorAction_Pause, // (None=0 はゼロ値省略で変更不可のため Pause 維持)
+		0,
+		api.StartAction_Start, // 変更: Nothing → Start
+		0,
+		api.StopAction_ShutDown, // 変更: Save → ShutDown
+		api.CheckpointType_Production,
+		false,
+		false,
+		0,
+		api.OnOffState_On, // 変更: lockOnDisconnect Off → On
+		0,
+		memByt, memByt, memByt,
+		"phase-d-update", // 変更: Notes
+		2,                // 変更: processorCount 1 → 2
+		"", "",
+		true,
+		false,
+	); err != nil {
+		t.Fatalf("UpdateVm: %v", err)
+	}
+
+	// --- 5. Get → 更新反映を検証 ---
+	vm2, err := cc.GetVm(ctx, name)
+	if err != nil {
+		t.Fatalf("GetVm(after update): %v", err)
+	}
+	if vm2.Notes != "phase-d-update" {
+		t.Errorf("Notes after Update = %q, want phase-d-update", vm2.Notes)
+	}
+	if vm2.AutomaticStartAction != api.StartAction_Start {
+		t.Errorf("AutomaticStartAction after Update = %v, want Start", vm2.AutomaticStartAction)
+	}
+	if vm2.AutomaticStopAction != api.StopAction_ShutDown {
+		t.Errorf("AutomaticStopAction after Update = %v, want ShutDown", vm2.AutomaticStopAction)
+	}
+	if vm2.LockOnDisconnect != api.OnOffState_On {
+		t.Errorf("LockOnDisconnect after Update = %v, want On", vm2.LockOnDisconnect)
+	}
+	t.Logf("UpdateVm OK: notes=%q start=%v stop=%v lock=%v",
+		vm2.Notes, vm2.AutomaticStartAction, vm2.AutomaticStopAction, vm2.LockOnDisconnect)
+
+	// --- 6. Delete → Exists false ---
+	if err := cc.DeleteVm(ctx, name); err != nil {
+		t.Fatalf("DeleteVm: %v", err)
+	}
+	ex2, err := cc.VmExists(ctx, name)
+	if err != nil {
+		t.Fatalf("VmExists(after delete): %v", err)
+	}
+	if ex2.Exists {
+		t.Error("VmExists after Delete = true, want false")
+	}
+	t.Logf("DeleteVm OK: %s removed", name)
+}


### PR DESCRIPTION
## 概要

Phase D 実機 acc test で go-wsman の write 経路バグを発見・修正 (go-wsman #82 マージ済) し、provider 側の VM CRUD を実機で動作させる。

## 変更内容

- **VM CRUD 実機統合テスト** (`internal/provider/vm_crud_integration_test.go`): go-wsman 経由の Create→Exists→Get→Update→Get→Delete を実 Hyper-V ホストで検証 (`-tags integration`)。ユニットテストでは検証できないオーケストレーション全体 (Phase D) を実機で確認
- **UpdateVm 最小instance修正** (`api/hyperv-wsman/vm.go`): ModifySystemSettings は「変更箇所 + InstanceID」のみ受け付けるため、GetSystemSettingData の全体ではなく InstanceID + 変更フィールドだけを渡す (全体送信は read-only プロパティでジョブ失敗)
- **go-wsman bump** (`go.mod`): Phase D 修正版 (#82) を取り込む

## 検証 (homelab Hyper-V 実機)

```
TestRealHostVmCrudWsman: CreateVm→GetVm→UpdateVm→DeleteVm 全ライフサイクル PASS
  CreateVm OK / GetVm OK (gen=2/notes/enum一致) / UpdateVm OK (変更反映) / DeleteVm OK
```

公開版 go-wsman (replace 無し) で再現確認済み。

## 関連

go-wsman #82 (WQL 列挙 + write 経路の実機動作修正、マージ済)