### PR TITLE
feat: disk/nic を go-wsman 経由に配線 (#63 B side)

### DIFF
--- a/api/hyperv-wsman/vm_hard_disk_drive.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive.go
@@ -379,16 +379,40 @@ func mapHardDiskDriveRefs(
 	return refs
 }
 
-// matchRefKey は EPR/参照文字列 ref に対応するマップのキーを返す (無ければ空文字)。
+// extractInstanceIDFromRef は go-wsman が返す親参照から InstanceID を取り出す。
 //
-// go-wsman の Unmarshal は Parent(EPR) から末尾の非空テキスト = InstanceID を取り出すため、
-// 通常は ref がそのままキーに一致する。実機で EPR ラッパーが残る場合に備え、包含一致も見る。
-func matchRefKey[V any](ref string, m map[string]V) string {
-	if _, ok := m[ref]; ok {
+// 実 Hyper-V の Parent/HostResource は WMI オブジェクトパス
+//
+//	\\HOST\root\...\v2:Msvm_...SettingData.InstanceID="Microsoft:GUID\\...\\0"
+//
+// 形式で、参照内の InstanceID 値はバックスラッシュが二重エスケープ (\\) される。一方 List 系が
+// 返す InstanceID は単一バックスラッシュ (\) なので、`.InstanceID="..."` を抽出して \\→\ に戻し、
+// 突き合わせできるようにする。ref が既に素の InstanceID (golden 等) の場合はそのまま返す。
+func extractInstanceIDFromRef(ref string) string {
+	const marker = `.InstanceID="`
+	i := strings.Index(ref, marker)
+	if i < 0 {
 		return ref
 	}
+	rest := ref[i+len(marker):]
+	if j := strings.LastIndex(rest, `"`); j >= 0 {
+		rest = rest[:j]
+	}
+	return strings.ReplaceAll(rest, `\\`, `\`)
+}
+
+// matchRefKey は EPR/参照文字列 ref に対応するマップのキーを返す (無ければ空文字)。
+//
+// 実 Hyper-V の Parent は WMI オブジェクトパス (InstanceID 二重エスケープ) のため、
+// extractInstanceIDFromRef で素の InstanceID に正規化してから突き合わせる。
+func matchRefKey[V any](ref string, m map[string]V) string {
+	id := extractInstanceIDFromRef(ref)
+	if _, ok := m[id]; ok {
+		return id
+	}
+	// フォールバック: 抽出後も一致しない場合の包含一致 (golden / 想定外形式のため)。
 	for k := range m {
-		if k != "" && strings.Contains(ref, k) {
+		if k != "" && strings.Contains(id, k) {
 			return k
 		}
 	}

--- a/api/hyperv-wsman/vm_hard_disk_drive.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive.go
@@ -100,6 +100,13 @@ func (c *ClientConfig) CreateVmHardDiskDrive(
 	if err != nil {
 		return fmt.Errorf("hyperv-wsman: CreateVmHardDiskDrive %q: %w", vmName, err)
 	}
+	// go-wsman で作った VM はシェル状態で SCSI Controller を持たない (#88) ため、SCSI
+	// アタッチ前に対象 Controller の存在を保証する。IDE は Gen1 に既定で存在するので対象外。
+	if controllerType == api.ControllerType_Scsi {
+		if err := c.ensureScsiController(ctx, vmName, controllerNumber); err != nil {
+			return err
+		}
+	}
 	_, err = c.WsmanClient.AttachVHD(ctx, vmName, hyperv.AttachVHDOptions{
 		ControllerType:     wsmanCT,
 		ControllerNumber:   int(controllerNumber),
@@ -108,6 +115,37 @@ func (c *ClientConfig) CreateVmHardDiskDrive(
 	})
 	if err != nil {
 		return fmt.Errorf("hyperv-wsman: CreateVmHardDiskDrive %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// ensureScsiController は controllerNumber 番目の SCSI Controller が存在することを保証する。
+//
+// go-wsman の DefineSystem はシェル VM を作り SCSI Controller を持たない (#88) ため、必要数に
+// 満たなければ AddScsiController で追加する。追加のたびに再列挙して件数を確認する (無限ループ防止)。
+func (c *ClientConfig) ensureScsiController(ctx context.Context, vmName string, controllerNumber int32) error {
+	controllers, err := c.WsmanClient.ListSCSIControllers(ctx, vmName)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: ensure SCSI controller %q: %w", vmName, err)
+	}
+	for int32(len(controllers)) <= controllerNumber {
+		res, err := c.WsmanClient.AddScsiController(ctx, vmName)
+		if err != nil {
+			return fmt.Errorf("hyperv-wsman: add SCSI controller %q: %w", vmName, err)
+		}
+		if res.JobRef != "" {
+			if err := c.WsmanClient.WaitForJob(ctx, res.JobRef); err != nil {
+				return fmt.Errorf("hyperv-wsman: wait add SCSI controller %q: %w", vmName, err)
+			}
+		}
+		next, err := c.WsmanClient.ListSCSIControllers(ctx, vmName)
+		if err != nil {
+			return fmt.Errorf("hyperv-wsman: ensure SCSI controller %q: %w", vmName, err)
+		}
+		if len(next) <= len(controllers) {
+			return fmt.Errorf("hyperv-wsman: add SCSI controller %q: 追加後も件数が増えない (%d)", vmName, len(next))
+		}
+		controllers = next
 	}
 	return nil
 }

--- a/api/hyperv-wsman/vm_hard_disk_drive.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive.go
@@ -76,6 +76,20 @@ func unsupportedHardDiskOptions(
 	return nil
 }
 
+// resolveVMGUID は VM の表示名 (ElementName) を go-wsman が要求する GUID
+// (Msvm_ComputerSystem.Name) に解決する。
+//
+// go-wsman の各メソッドの vmName 引数は GUID 契約 (matchSettingDataVM が
+// "Microsoft:<GUID>" 前方一致でフィルタする)。terraform から来る表示名をそのまま渡すと
+// 列挙が silent に空を返すため、必ず本関数で解決してから go-wsman を呼ぶ。
+func (c *ClientConfig) resolveVMGUID(ctx context.Context, name string) (string, error) {
+	cs, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("resolve VM %q: %w", name, err)
+	}
+	return cs.Name, nil
+}
+
 // CreateVmHardDiskDrive は go-wsman 経由で VHD を IDE/SCSI Controller にアタッチする。
 func (c *ClientConfig) CreateVmHardDiskDrive(
 	ctx context.Context,
@@ -100,14 +114,18 @@ func (c *ClientConfig) CreateVmHardDiskDrive(
 	if err != nil {
 		return fmt.Errorf("hyperv-wsman: CreateVmHardDiskDrive %q: %w", vmName, err)
 	}
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmHardDiskDrive %q: %w", vmName, err)
+	}
 	// go-wsman で作った VM はシェル状態で SCSI Controller を持たない (#88) ため、SCSI
 	// アタッチ前に対象 Controller の存在を保証する。IDE は Gen1 に既定で存在するので対象外。
 	if controllerType == api.ControllerType_Scsi {
-		if err := c.ensureScsiController(ctx, vmName, controllerNumber); err != nil {
+		if err := c.ensureScsiController(ctx, guid, controllerNumber); err != nil {
 			return err
 		}
 	}
-	_, err = c.WsmanClient.AttachVHD(ctx, vmName, hyperv.AttachVHDOptions{
+	_, err = c.WsmanClient.AttachVHD(ctx, guid, hyperv.AttachVHDOptions{
 		ControllerType:     wsmanCT,
 		ControllerNumber:   int(controllerNumber),
 		ControllerLocation: int(controllerLocation),
@@ -120,30 +138,31 @@ func (c *ClientConfig) CreateVmHardDiskDrive(
 }
 
 // ensureScsiController は controllerNumber 番目の SCSI Controller が存在することを保証する。
+// vmGUID は解決済みの VM GUID (呼び出し側で resolveVMGUID 済み)。
 //
 // go-wsman の DefineSystem はシェル VM を作り SCSI Controller を持たない (#88) ため、必要数に
 // 満たなければ AddScsiController で追加する。追加のたびに再列挙して件数を確認する (無限ループ防止)。
-func (c *ClientConfig) ensureScsiController(ctx context.Context, vmName string, controllerNumber int32) error {
-	controllers, err := c.WsmanClient.ListSCSIControllers(ctx, vmName)
+func (c *ClientConfig) ensureScsiController(ctx context.Context, vmGUID string, controllerNumber int32) error {
+	controllers, err := c.WsmanClient.ListSCSIControllers(ctx, vmGUID)
 	if err != nil {
-		return fmt.Errorf("hyperv-wsman: ensure SCSI controller %q: %w", vmName, err)
+		return fmt.Errorf("hyperv-wsman: ensure SCSI controller %q: %w", vmGUID, err)
 	}
 	for int32(len(controllers)) <= controllerNumber {
-		res, err := c.WsmanClient.AddScsiController(ctx, vmName)
+		res, err := c.WsmanClient.AddScsiController(ctx, vmGUID)
 		if err != nil {
-			return fmt.Errorf("hyperv-wsman: add SCSI controller %q: %w", vmName, err)
+			return fmt.Errorf("hyperv-wsman: add SCSI controller %q: %w", vmGUID, err)
 		}
 		if res.JobRef != "" {
 			if err := c.WsmanClient.WaitForJob(ctx, res.JobRef); err != nil {
-				return fmt.Errorf("hyperv-wsman: wait add SCSI controller %q: %w", vmName, err)
+				return fmt.Errorf("hyperv-wsman: wait add SCSI controller %q: %w", vmGUID, err)
 			}
 		}
-		next, err := c.WsmanClient.ListSCSIControllers(ctx, vmName)
+		next, err := c.WsmanClient.ListSCSIControllers(ctx, vmGUID)
 		if err != nil {
-			return fmt.Errorf("hyperv-wsman: ensure SCSI controller %q: %w", vmName, err)
+			return fmt.Errorf("hyperv-wsman: ensure SCSI controller %q: %w", vmGUID, err)
 		}
 		if len(next) <= len(controllers) {
-			return fmt.Errorf("hyperv-wsman: add SCSI controller %q: 追加後も件数が増えない (%d)", vmName, len(next))
+			return fmt.Errorf("hyperv-wsman: add SCSI controller %q: 追加後も件数が増えない (%d)", vmGUID, len(next))
 		}
 		controllers = next
 	}
@@ -161,19 +180,23 @@ type hardDiskDriveRef struct {
 // storage(ファイル) → drive(Controller内位置) → controller(IDE/SCSI種別・番号) の 3 段結合で
 // provider の VmHardDiskDrive を復元する。Detach 用に Drive の InstanceID も保持する。
 func (c *ClientConfig) getHardDiskDriveRefs(ctx context.Context, vmName string) ([]hardDiskDriveRef, error) {
-	storages, err := c.WsmanClient.ListAttachedStorage(ctx, vmName)
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: get hard disk drives %q: %w", vmName, err)
+	}
+	storages, err := c.WsmanClient.ListAttachedStorage(ctx, guid)
 	if err != nil {
 		return nil, fmt.Errorf("hyperv-wsman: list attached storage %q: %w", vmName, err)
 	}
-	drives, err := c.WsmanClient.ListDiskDrives(ctx, vmName)
+	drives, err := c.WsmanClient.ListDiskDrives(ctx, guid)
 	if err != nil {
 		return nil, fmt.Errorf("hyperv-wsman: list disk drives %q: %w", vmName, err)
 	}
-	ideCtrls, err := c.WsmanClient.ListIDEControllers(ctx, vmName)
+	ideCtrls, err := c.WsmanClient.ListIDEControllers(ctx, guid)
 	if err != nil {
 		return nil, fmt.Errorf("hyperv-wsman: list IDE controllers %q: %w", vmName, err)
 	}
-	scsiCtrls, err := c.WsmanClient.ListSCSIControllers(ctx, vmName)
+	scsiCtrls, err := c.WsmanClient.ListSCSIControllers(ctx, guid)
 	if err != nil {
 		return nil, fmt.Errorf("hyperv-wsman: list SCSI controllers %q: %w", vmName, err)
 	}
@@ -295,7 +318,12 @@ func mapHardDiskDriveRefs(
 	for _, d := range drives {
 		driveByID[d.InstanceID] = d
 	}
-	// controller InstanceID → (種別, 番号)
+	// controller InstanceID → (種別, 番号)。
+	// WS-Man の列挙順は無保証なので、InstanceID でソートしてから番号を振る。読み取りごとに番号が
+	// 入れ替わると全 disk のキーが変わり誤 detach/attach を招くため決定的順序が必須 (H2)。
+	// go-wsman 側 attachStorage も同じ InstanceID ソートで controllers[番号] を選ぶ (書き込みと一致)。
+	sortByInstanceID(ideCtrls)
+	sortByInstanceID(scsiCtrls)
 	type ctrlInfo struct {
 		ct     api.ControllerType
 		number int32
@@ -323,7 +351,12 @@ func mapHardDiskDriveRefs(
 		}
 		// AddressOnParent は Controller 内 location (IDE 0-1 / SCSI 0-63)。int32 に収まる範囲で
 		// パースする (ParseInt bitSize=32 で上限保証、CodeQL go/incorrect-integer-conversion 対策)。
-		location, _ := strconv.ParseInt(drive.AddressOnParent, 10, 32)
+		// パース失敗は握り潰さずスキップする (location=0 に化けると実在の 0 番 disk とキー衝突し
+		// reconcile が誤判断するため、M4)。
+		location, err := strconv.ParseInt(drive.AddressOnParent, 10, 32)
+		if err != nil {
+			continue
+		}
 		refs = append(refs, hardDiskDriveRef{
 			driveInstanceID: drive.InstanceID,
 			drive: api.VmHardDiskDrive{
@@ -362,6 +395,13 @@ func matchRefKey[V any](ref string, m map[string]V) string {
 	return ""
 }
 
+// sortByInstanceID は Controller 一覧を InstanceID で安定ソートする (番号採番の決定性のため)。
+func sortByInstanceID(items []*hyperv.Msvm_ResourceAllocationSettingData) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].InstanceID < items[j].InstanceID
+	})
+}
+
 // sortHardDiskDriveRefs は (種別, Controller番号, 位置) で安定ソートする (index の決定性のため)。
 func sortHardDiskDriveRefs(refs []hardDiskDriveRef) {
 	sort.SliceStable(refs, func(i, j int) bool {
@@ -382,13 +422,40 @@ func hardDiskDriveKey(d api.VmHardDiskDrive) string {
 	return fmt.Sprintf("%d/%d/%d/%s", d.ControllerType, d.ControllerNumber, d.ControllerLocation, strings.ToLower(d.Path))
 }
 
+// isAvhdx はパスが差分ディスク (チェックポイントの .avhdx) かどうかを返す。
+func isAvhdx(path string) bool {
+	return strings.HasSuffix(strings.ToLower(path), ".avhdx")
+}
+
+// diskSlotKey は disk の物理スロット (種別, Controller番号, 位置) を表す (パスを含めない)。
+func diskSlotKey(d api.VmHardDiskDrive) string {
+	return fmt.Sprintf("%d/%d/%d", d.ControllerType, d.ControllerNumber, d.ControllerLocation)
+}
+
 // planHardDiskDriveReconcile は現状 refs を所望 desired に収束させる detach/attach 計画を返す。
 //
 // 現状にあって所望に無いものを Detach (Drive InstanceID)、所望にあって現状に無いものを Attach。
+//
+// チェックポイント保護 (M3): VM にスナップショットがあると Get は差分ディスク (.avhdx) のパスを返すが
+// config は基底 (.vhdx) を持つため、素朴にキー比較すると detach→attach してスナップショットチェーンを
+// 破壊する。基底↔差分の対応はパス単体からは一意に判定できない (基底名にアンダースコアを含み得る) ため、
+// .avhdx が占めるスロット (種別/番号/位置) は「触らない」= detach もそのスロットへの attach もしない、
+// という保守的な扱いにする。チェックポイント運用の本格対応は別途 (#46 の v2.1)。
+//
 // 純関数なので table-driven test で検証できる。
 func planHardDiskDriveReconcile(current []hardDiskDriveRef, desired []api.VmHardDiskDrive) (toDetach []string, toAttach []api.VmHardDiskDrive) {
-	currentKeys := make(map[string]string, len(current)) // key → driveInstanceID
+	// .avhdx が占めるスロットを収集 (このスロットは detach/attach 対象外)。
+	checkpointSlots := make(map[string]struct{})
 	for _, r := range current {
+		if isAvhdx(r.drive.Path) {
+			checkpointSlots[diskSlotKey(r.drive)] = struct{}{}
+		}
+	}
+	currentKeys := make(map[string]string, len(current)) // key → driveInstanceID (.avhdx は除外)
+	for _, r := range current {
+		if isAvhdx(r.drive.Path) {
+			continue
+		}
 		currentKeys[hardDiskDriveKey(r.drive)] = r.driveInstanceID
 	}
 	desiredKeys := make(map[string]struct{}, len(desired))
@@ -396,11 +463,17 @@ func planHardDiskDriveReconcile(current []hardDiskDriveRef, desired []api.VmHard
 		desiredKeys[hardDiskDriveKey(d)] = struct{}{}
 	}
 	for _, r := range current {
+		if isAvhdx(r.drive.Path) {
+			continue // チェックポイントの差分ディスクは detach しない
+		}
 		if _, ok := desiredKeys[hardDiskDriveKey(r.drive)]; !ok {
 			toDetach = append(toDetach, r.driveInstanceID)
 		}
 	}
 	for _, d := range desired {
+		if _, ok := checkpointSlots[diskSlotKey(d)]; ok {
+			continue // チェックポイントが占めるスロットには attach しない
+		}
 		if _, ok := currentKeys[hardDiskDriveKey(d)]; !ok {
 			toAttach = append(toAttach, d)
 		}

--- a/api/hyperv-wsman/vm_hard_disk_drive.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive.go
@@ -125,13 +125,13 @@ func (c *ClientConfig) CreateVmHardDiskDrive(
 			return err
 		}
 	}
-	_, err = c.WsmanClient.AttachVHD(ctx, guid, hyperv.AttachVHDOptions{
+	// AttachVHD は内部で Drive/Storage の非同期 Job 完了まで待つ (go-wsman 側)。
+	if _, err := c.WsmanClient.AttachVHD(ctx, guid, hyperv.AttachVHDOptions{
 		ControllerType:     wsmanCT,
 		ControllerNumber:   int(controllerNumber),
 		ControllerLocation: int(controllerLocation),
 		Path:               path,
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("hyperv-wsman: CreateVmHardDiskDrive %q: %w", vmName, err)
 	}
 	return nil

--- a/api/hyperv-wsman/vm_hard_disk_drive.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive.go
@@ -169,10 +169,14 @@ func (c *ClientConfig) ensureScsiController(ctx context.Context, vmGUID string, 
 	return nil
 }
 
-// hardDiskDriveRef は 1 本の VHD アタッチと、その Detach に必要な Drive InstanceID を束ねる。
+// hardDiskDriveRef は 1 本の VHD アタッチと、その Detach に必要な InstanceID を束ねる。
+//
+// Detach は「Storage (SASD) 削除 → Drive (RASD) 削除」の 2 段が必須なため、Drive だけでなく
+// Storage の InstanceID も保持する (子 SASD を残したまま Drive を消すと VMMS が拒否する #97)。
 type hardDiskDriveRef struct {
-	drive           api.VmHardDiskDrive
-	driveInstanceID string // Msvm_ResourceAllocationSettingData (Disk Drive) の InstanceID
+	drive             api.VmHardDiskDrive
+	driveInstanceID   string // Msvm_ResourceAllocationSettingData (Disk Drive) の InstanceID
+	storageInstanceID string // Msvm_StorageAllocationSettingData (VHD) の InstanceID
 }
 
 // getHardDiskDriveRefs は VM の VHD 一覧を go-wsman の逆引きで組み立てる (順序安定)。
@@ -218,8 +222,8 @@ func (c *ClientConfig) GetVmHardDiskDrives(ctx context.Context, vmName string) (
 
 // DeleteVmHardDiskDrive は index 番目の VHD を go-wsman 経由で Detach する。
 //
-// index は GetVmHardDiskDrives が返す順序に対応する。逆引きで Drive InstanceID を解決して
-// DetachStorage を呼ぶ (Drive を消すと紐づく Storage も連鎖削除される)。
+// index は GetVmHardDiskDrives が返す順序に対応する。逆引きで Storage/Drive の InstanceID を
+// 解決して DetachStorage を呼ぶ (Storage → Drive の 2 段削除)。
 func (c *ClientConfig) DeleteVmHardDiskDrive(ctx context.Context, vmName string, index int) error {
 	refs, err := c.getHardDiskDriveRefs(ctx, vmName)
 	if err != nil {
@@ -228,7 +232,7 @@ func (c *ClientConfig) DeleteVmHardDiskDrive(ctx context.Context, vmName string,
 	if index < 0 || index >= len(refs) {
 		return fmt.Errorf("hyperv-wsman: DeleteVmHardDiskDrive %q: index %d out of range (VM has %d disks)", vmName, index, len(refs))
 	}
-	if _, err := c.WsmanClient.DetachStorage(ctx, refs[index].driveInstanceID); err != nil {
+	if _, err := c.WsmanClient.DetachStorage(ctx, refs[index].driveInstanceID, refs[index].storageInstanceID); err != nil {
 		return fmt.Errorf("hyperv-wsman: DeleteVmHardDiskDrive %q: %w", vmName, err)
 	}
 	return nil
@@ -284,8 +288,8 @@ func (c *ClientConfig) CreateOrUpdateVmHardDiskDrives(ctx context.Context, vmNam
 		return err
 	}
 	toDetach, toAttach := planHardDiskDriveReconcile(current, hardDiskDrives)
-	for _, driveInstanceID := range toDetach {
-		if _, err := c.WsmanClient.DetachStorage(ctx, driveInstanceID); err != nil {
+	for _, r := range toDetach {
+		if _, err := c.WsmanClient.DetachStorage(ctx, r.driveInstanceID, r.storageInstanceID); err != nil {
 			return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmHardDiskDrives %q: detach: %w", vmName, err)
 		}
 	}
@@ -358,7 +362,8 @@ func mapHardDiskDriveRefs(
 			continue
 		}
 		refs = append(refs, hardDiskDriveRef{
-			driveInstanceID: drive.InstanceID,
+			driveInstanceID:   drive.InstanceID,
+			storageInstanceID: s.InstanceID,
 			drive: api.VmHardDiskDrive{
 				VmName:                        vmName,
 				ControllerType:                ci.ct,
@@ -458,7 +463,8 @@ func diskSlotKey(d api.VmHardDiskDrive) string {
 
 // planHardDiskDriveReconcile は現状 refs を所望 desired に収束させる detach/attach 計画を返す。
 //
-// 現状にあって所望に無いものを Detach (Drive InstanceID)、所望にあって現状に無いものを Attach。
+// 現状にあって所望に無いものを Detach (Storage/Drive の 2 段削除に両 InstanceID が要る)、
+// 所望にあって現状に無いものを Attach。
 //
 // チェックポイント保護 (M3): VM にスナップショットがあると Get は差分ディスク (.avhdx) のパスを返すが
 // config は基底 (.vhdx) を持つため、素朴にキー比較すると detach→attach してスナップショットチェーンを
@@ -467,7 +473,7 @@ func diskSlotKey(d api.VmHardDiskDrive) string {
 // という保守的な扱いにする。チェックポイント運用の本格対応は別途 (#46 の v2.1)。
 //
 // 純関数なので table-driven test で検証できる。
-func planHardDiskDriveReconcile(current []hardDiskDriveRef, desired []api.VmHardDiskDrive) (toDetach []string, toAttach []api.VmHardDiskDrive) {
+func planHardDiskDriveReconcile(current []hardDiskDriveRef, desired []api.VmHardDiskDrive) (toDetach []hardDiskDriveRef, toAttach []api.VmHardDiskDrive) {
 	// .avhdx が占めるスロットを収集 (このスロットは detach/attach 対象外)。
 	checkpointSlots := make(map[string]struct{})
 	for _, r := range current {
@@ -491,7 +497,7 @@ func planHardDiskDriveReconcile(current []hardDiskDriveRef, desired []api.VmHard
 			continue // チェックポイントの差分ディスクは detach しない
 		}
 		if _, ok := desiredKeys[hardDiskDriveKey(r.drive)]; !ok {
-			toDetach = append(toDetach, r.driveInstanceID)
+			toDetach = append(toDetach, r)
 		}
 	}
 	for _, d := range desired {

--- a/api/hyperv-wsman/vm_hard_disk_drive.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive.go
@@ -1,0 +1,369 @@
+package hyperv_wsman
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// hard_disk_drives スキーマの「未設定」を表す既定値 (data_source/resource schema と一致)。
+// これらの既定値は go-wsman が扱えなくても素通しし、既定以外が指定された時だけ拒否する。
+const (
+	hardDiskDiskNumberUnset   = uint32(4294967295) // MaxUint32 = passthrough 無効 (VHD パスモード)
+	hardDiskDefaultPool       = "Primordial"       // 既定リソースプール
+	hardDiskZeroQosPolicyGUID = "00000000-0000-0000-0000-000000000000"
+)
+
+// wsmanControllerType は provider の ControllerType を go-wsman の ControllerType に変換する。
+func wsmanControllerType(ct api.ControllerType) (hyperv.ControllerType, error) {
+	switch ct {
+	case api.ControllerType_Ide:
+		return hyperv.ControllerTypeIDE, nil
+	case api.ControllerType_Scsi:
+		return hyperv.ControllerTypeSCSI, nil
+	default:
+		return "", fmt.Errorf("unsupported controller type %d", ct)
+	}
+}
+
+// unsupportedHardDiskOptions は go-wsman 経路が未対応のオプションが指定されていれば error を返す。
+//
+// silent drop を避けるため (rules: 未対応を黙って無視しない)、QoS・パススルーディスク・
+// カスタムリソースプール・キャッシュ属性・永続予約が既定以外なら明示的に拒否する。これらは
+// v2.1 以降で go-wsman に実装予定。VHD パス + IDE/SCSI 位置指定のみ本経路でサポートする。
+func unsupportedHardDiskOptions(
+	diskNumber uint32,
+	resourcePoolName string,
+	supportPersistentReservations bool,
+	maximumIops uint64,
+	minimumIops uint64,
+	qosPolicyId string,
+	overrideCacheAttributes api.CacheAttributes,
+) error {
+	var unsupported []string
+	if diskNumber != hardDiskDiskNumberUnset {
+		unsupported = append(unsupported, "disk_number (パススルー物理ディスク)")
+	}
+	if resourcePoolName != "" && resourcePoolName != hardDiskDefaultPool {
+		unsupported = append(unsupported, "resource_pool_name")
+	}
+	if supportPersistentReservations {
+		unsupported = append(unsupported, "support_persistent_reservations")
+	}
+	if maximumIops != 0 {
+		unsupported = append(unsupported, "maximum_iops")
+	}
+	if minimumIops != 0 {
+		unsupported = append(unsupported, "minimum_iops")
+	}
+	if qosPolicyId != "" && qosPolicyId != hardDiskZeroQosPolicyGUID {
+		unsupported = append(unsupported, "qos_policy_id")
+	}
+	if overrideCacheAttributes != api.CacheAttributes_Default {
+		unsupported = append(unsupported, "override_cache_attributes")
+	}
+	if len(unsupported) > 0 {
+		return fmt.Errorf(
+			"hyperv-wsman: hard_disk_drive のオプション %s は go-wsman 経路 (HYPERV_USE_WSMAN) では未対応です。"+
+				"PowerShell 経路 (HYPERV_USE_WSMAN 未設定) を使うか、これらを既定値にしてください",
+			strings.Join(unsupported, ", "))
+	}
+	return nil
+}
+
+// CreateVmHardDiskDrive は go-wsman 経由で VHD を IDE/SCSI Controller にアタッチする。
+func (c *ClientConfig) CreateVmHardDiskDrive(
+	ctx context.Context,
+	vmName string,
+	controllerType api.ControllerType,
+	controllerNumber int32,
+	controllerLocation int32,
+	path string,
+	diskNumber uint32,
+	resourcePoolName string,
+	supportPersistentReservations bool,
+	maximumIops uint64,
+	minimumIops uint64,
+	qosPolicyId string,
+	overrideCacheAttributes api.CacheAttributes,
+) error {
+	if err := unsupportedHardDiskOptions(diskNumber, resourcePoolName, supportPersistentReservations,
+		maximumIops, minimumIops, qosPolicyId, overrideCacheAttributes); err != nil {
+		return err
+	}
+	wsmanCT, err := wsmanControllerType(controllerType)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmHardDiskDrive %q: %w", vmName, err)
+	}
+	_, err = c.WsmanClient.AttachVHD(ctx, vmName, hyperv.AttachVHDOptions{
+		ControllerType:     wsmanCT,
+		ControllerNumber:   int(controllerNumber),
+		ControllerLocation: int(controllerLocation),
+		Path:               path,
+	})
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmHardDiskDrive %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// hardDiskDriveRef は 1 本の VHD アタッチと、その Detach に必要な Drive InstanceID を束ねる。
+type hardDiskDriveRef struct {
+	drive           api.VmHardDiskDrive
+	driveInstanceID string // Msvm_ResourceAllocationSettingData (Disk Drive) の InstanceID
+}
+
+// getHardDiskDriveRefs は VM の VHD 一覧を go-wsman の逆引きで組み立てる (順序安定)。
+//
+// storage(ファイル) → drive(Controller内位置) → controller(IDE/SCSI種別・番号) の 3 段結合で
+// provider の VmHardDiskDrive を復元する。Detach 用に Drive の InstanceID も保持する。
+func (c *ClientConfig) getHardDiskDriveRefs(ctx context.Context, vmName string) ([]hardDiskDriveRef, error) {
+	storages, err := c.WsmanClient.ListAttachedStorage(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list attached storage %q: %w", vmName, err)
+	}
+	drives, err := c.WsmanClient.ListDiskDrives(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list disk drives %q: %w", vmName, err)
+	}
+	ideCtrls, err := c.WsmanClient.ListIDEControllers(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list IDE controllers %q: %w", vmName, err)
+	}
+	scsiCtrls, err := c.WsmanClient.ListSCSIControllers(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list SCSI controllers %q: %w", vmName, err)
+	}
+	return mapHardDiskDriveRefs(vmName, storages, drives, ideCtrls, scsiCtrls), nil
+}
+
+// GetVmHardDiskDrives は VM にアタッチされた VHD 一覧を返す (go-wsman 逆引き)。
+func (c *ClientConfig) GetVmHardDiskDrives(ctx context.Context, vmName string) ([]api.VmHardDiskDrive, error) {
+	refs, err := c.getHardDiskDriveRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]api.VmHardDiskDrive, 0, len(refs))
+	for _, r := range refs {
+		result = append(result, r.drive)
+	}
+	return result, nil
+}
+
+// DeleteVmHardDiskDrive は index 番目の VHD を go-wsman 経由で Detach する。
+//
+// index は GetVmHardDiskDrives が返す順序に対応する。逆引きで Drive InstanceID を解決して
+// DetachStorage を呼ぶ (Drive を消すと紐づく Storage も連鎖削除される)。
+func (c *ClientConfig) DeleteVmHardDiskDrive(ctx context.Context, vmName string, index int) error {
+	refs, err := c.getHardDiskDriveRefs(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	if index < 0 || index >= len(refs) {
+		return fmt.Errorf("hyperv-wsman: DeleteVmHardDiskDrive %q: index %d out of range (VM has %d disks)", vmName, index, len(refs))
+	}
+	if _, err := c.WsmanClient.DetachStorage(ctx, refs[index].driveInstanceID); err != nil {
+		return fmt.Errorf("hyperv-wsman: DeleteVmHardDiskDrive %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// UpdateVmHardDiskDrive は index 番目の VHD を所望の状態に置き換える。
+//
+// go-wsman には Controller/位置の in-place 変更が無いため、既存 Drive を Detach してから
+// 新しい設定で AttachVHD する (再作成)。
+func (c *ClientConfig) UpdateVmHardDiskDrive(
+	ctx context.Context,
+	vmName string,
+	index int,
+	controllerType api.ControllerType,
+	controllerNumber int32,
+	controllerLocation int32,
+	path string,
+	diskNumber uint32,
+	resourcePoolName string,
+	supportPersistentReservations bool,
+	maximumIops uint64,
+	minimumIops uint64,
+	qosPolicyId string,
+	overrideCacheAttributes api.CacheAttributes,
+) error {
+	if err := unsupportedHardDiskOptions(diskNumber, resourcePoolName, supportPersistentReservations,
+		maximumIops, minimumIops, qosPolicyId, overrideCacheAttributes); err != nil {
+		return err
+	}
+	if err := c.DeleteVmHardDiskDrive(ctx, vmName, index); err != nil {
+		return err
+	}
+	return c.CreateVmHardDiskDrive(ctx, vmName, controllerType, controllerNumber, controllerLocation,
+		path, diskNumber, resourcePoolName, supportPersistentReservations, maximumIops, minimumIops,
+		qosPolicyId, overrideCacheAttributes)
+}
+
+// CreateOrUpdateVmHardDiskDrives は所望の VHD 集合に収束させる (go-wsman)。
+//
+// go-wsman は attach/detach しか持たないため、in-place 更新ではなく集合差分で収束する:
+// 現状にあって所望に無い VHD を Detach、所望にあって現状に無い VHD を Attach する。
+// Controller 種別変更も「旧 Detach + 新 Attach」で自然に処理される。冪等。
+func (c *ClientConfig) CreateOrUpdateVmHardDiskDrives(ctx context.Context, vmName string, hardDiskDrives []api.VmHardDiskDrive) error {
+	// 未対応オプションは適用前に全件チェックし、部分適用を避ける。
+	for _, d := range hardDiskDrives {
+		if err := unsupportedHardDiskOptions(d.DiskNumber, d.ResourcePoolName, d.SupportPersistentReservations,
+			d.MaximumIops, d.MinimumIops, d.QosPolicyId, d.OverrideCacheAttributes); err != nil {
+			return err
+		}
+	}
+	current, err := c.getHardDiskDriveRefs(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	toDetach, toAttach := planHardDiskDriveReconcile(current, hardDiskDrives)
+	for _, driveInstanceID := range toDetach {
+		if _, err := c.WsmanClient.DetachStorage(ctx, driveInstanceID); err != nil {
+			return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmHardDiskDrives %q: detach: %w", vmName, err)
+		}
+	}
+	for _, d := range toAttach {
+		if err := c.CreateVmHardDiskDrive(ctx, vmName, d.ControllerType, d.ControllerNumber, d.ControllerLocation,
+			d.Path, d.DiskNumber, d.ResourcePoolName, d.SupportPersistentReservations, d.MaximumIops, d.MinimumIops,
+			d.QosPolicyId, d.OverrideCacheAttributes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// --- 純関数 (table-driven test 対象) ---
+
+// mapHardDiskDriveRefs は go-wsman の storage/drive/controller 一覧を結合して VmHardDiskDrive を復元する。
+//
+// storage.Parent → drive.InstanceID、drive.Parent → controller.InstanceID の 2 段で親を辿り、
+// controller が IDE/SCSI どちらの一覧に居るかで種別を、一覧内の順序で controller 番号を決める。
+// VHD (Virtual Hard Disk) のみ対象とし、DVD/ISO は除外する。結果は (種別, 番号, 位置) で安定ソート。
+func mapHardDiskDriveRefs(
+	vmName string,
+	storages []*hyperv.Msvm_StorageAllocationSettingData,
+	drives []*hyperv.Msvm_ResourceAllocationSettingData,
+	ideCtrls []*hyperv.Msvm_ResourceAllocationSettingData,
+	scsiCtrls []*hyperv.Msvm_ResourceAllocationSettingData,
+) []hardDiskDriveRef {
+	// drive InstanceID → drive
+	driveByID := make(map[string]*hyperv.Msvm_ResourceAllocationSettingData, len(drives))
+	for _, d := range drives {
+		driveByID[d.InstanceID] = d
+	}
+	// controller InstanceID → (種別, 番号)
+	type ctrlInfo struct {
+		ct     api.ControllerType
+		number int32
+	}
+	ctrlByID := make(map[string]ctrlInfo)
+	for i, cc := range ideCtrls {
+		ctrlByID[cc.InstanceID] = ctrlInfo{ct: api.ControllerType_Ide, number: int32(i)}
+	}
+	for i, cc := range scsiCtrls {
+		ctrlByID[cc.InstanceID] = ctrlInfo{ct: api.ControllerType_Scsi, number: int32(i)}
+	}
+
+	refs := make([]hardDiskDriveRef, 0, len(storages))
+	for _, s := range storages {
+		if s.ResourceSubType != hyperv.ResourceSubTypeVirtualHardDisk {
+			continue // DVD/ISO は対象外
+		}
+		drive := driveByID[matchRefKey(s.Parent, driveByID)]
+		if drive == nil {
+			continue // 親 Drive が特定できない (整合しないデータ) はスキップ
+		}
+		ci, ok := ctrlByID[matchRefKey(drive.Parent, ctrlByID)]
+		if !ok {
+			continue // 親 Controller が特定できない
+		}
+		location, _ := strconv.Atoi(drive.AddressOnParent)
+		refs = append(refs, hardDiskDriveRef{
+			driveInstanceID: drive.InstanceID,
+			drive: api.VmHardDiskDrive{
+				VmName:                        vmName,
+				ControllerType:                ci.ct,
+				ControllerNumber:              ci.number,
+				ControllerLocation:            int32(location),
+				Path:                          s.HostResource,
+				DiskNumber:                    hardDiskDiskNumberUnset,
+				ResourcePoolName:              hardDiskDefaultPool,
+				SupportPersistentReservations: false,
+				MaximumIops:                   0,
+				MinimumIops:                   0,
+				QosPolicyId:                   hardDiskZeroQosPolicyGUID,
+				OverrideCacheAttributes:       api.CacheAttributes_Default,
+			},
+		})
+	}
+	sortHardDiskDriveRefs(refs)
+	return refs
+}
+
+// matchRefKey は EPR/参照文字列 ref に対応するマップのキーを返す (無ければ空文字)。
+//
+// go-wsman の Unmarshal は Parent(EPR) から末尾の非空テキスト = InstanceID を取り出すため、
+// 通常は ref がそのままキーに一致する。実機で EPR ラッパーが残る場合に備え、包含一致も見る。
+func matchRefKey[V any](ref string, m map[string]V) string {
+	if _, ok := m[ref]; ok {
+		return ref
+	}
+	for k := range m {
+		if k != "" && strings.Contains(ref, k) {
+			return k
+		}
+	}
+	return ""
+}
+
+// sortHardDiskDriveRefs は (種別, Controller番号, 位置) で安定ソートする (index の決定性のため)。
+func sortHardDiskDriveRefs(refs []hardDiskDriveRef) {
+	sort.SliceStable(refs, func(i, j int) bool {
+		a, b := refs[i].drive, refs[j].drive
+		if a.ControllerType != b.ControllerType {
+			return a.ControllerType < b.ControllerType
+		}
+		if a.ControllerNumber != b.ControllerNumber {
+			return a.ControllerNumber < b.ControllerNumber
+		}
+		return a.ControllerLocation < b.ControllerLocation
+	})
+}
+
+// hardDiskDriveKey は VHD の同一性を (種別, Controller番号, 位置, パス) で表す。
+// パスは Windows の大小非依存を考慮して小文字化する。
+func hardDiskDriveKey(d api.VmHardDiskDrive) string {
+	return fmt.Sprintf("%d/%d/%d/%s", d.ControllerType, d.ControllerNumber, d.ControllerLocation, strings.ToLower(d.Path))
+}
+
+// planHardDiskDriveReconcile は現状 refs を所望 desired に収束させる detach/attach 計画を返す。
+//
+// 現状にあって所望に無いものを Detach (Drive InstanceID)、所望にあって現状に無いものを Attach。
+// 純関数なので table-driven test で検証できる。
+func planHardDiskDriveReconcile(current []hardDiskDriveRef, desired []api.VmHardDiskDrive) (toDetach []string, toAttach []api.VmHardDiskDrive) {
+	currentKeys := make(map[string]string, len(current)) // key → driveInstanceID
+	for _, r := range current {
+		currentKeys[hardDiskDriveKey(r.drive)] = r.driveInstanceID
+	}
+	desiredKeys := make(map[string]struct{}, len(desired))
+	for _, d := range desired {
+		desiredKeys[hardDiskDriveKey(d)] = struct{}{}
+	}
+	for _, r := range current {
+		if _, ok := desiredKeys[hardDiskDriveKey(r.drive)]; !ok {
+			toDetach = append(toDetach, r.driveInstanceID)
+		}
+	}
+	for _, d := range desired {
+		if _, ok := currentKeys[hardDiskDriveKey(d)]; !ok {
+			toAttach = append(toAttach, d)
+		}
+	}
+	return toDetach, toAttach
+}

--- a/api/hyperv-wsman/vm_hard_disk_drive.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive.go
@@ -283,14 +283,16 @@ func mapHardDiskDriveRefs(
 		if !ok {
 			continue // 親 Controller が特定できない
 		}
-		location, _ := strconv.Atoi(drive.AddressOnParent)
+		// AddressOnParent は Controller 内 location (IDE 0-1 / SCSI 0-63)。int32 に収まる範囲で
+		// パースする (ParseInt bitSize=32 で上限保証、CodeQL go/incorrect-integer-conversion 対策)。
+		location, _ := strconv.ParseInt(drive.AddressOnParent, 10, 32)
 		refs = append(refs, hardDiskDriveRef{
 			driveInstanceID: drive.InstanceID,
 			drive: api.VmHardDiskDrive{
 				VmName:                        vmName,
 				ControllerType:                ci.ct,
 				ControllerNumber:              ci.number,
-				ControllerLocation:            int32(location),
+				ControllerLocation:            int32(location), // ParseInt(bitSize=32) 済みで安全
 				Path:                          s.HostResource,
 				DiskNumber:                    hardDiskDiskNumberUnset,
 				ResourcePoolName:              hardDiskDefaultPool,

--- a/api/hyperv-wsman/vm_hard_disk_drive_test.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive_test.go
@@ -2,6 +2,7 @@ package hyperv_wsman
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/r4sd/go-wsman/hyperv"
@@ -192,6 +193,50 @@ func TestMapHardDiskDriveRefs_ParseFailureSkipped(t *testing.T) {
 	)
 	if len(got) != 0 {
 		t.Errorf("AddressOnParent パース失敗の drive はスキップされるべき; got %d", len(got))
+	}
+}
+
+// TestExtractInstanceIDFromRef は実 Hyper-V の WMI オブジェクトパス (InstanceID 二重エスケープ) から
+// 素の InstanceID を取り出せることを検証する。
+func TestExtractInstanceIDFromRef(t *testing.T) {
+	// 実機の Parent 形式 (バックスラッシュ二重エスケープ)。
+	ref := `\\HOST\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="Microsoft:27BBD2D0\\83F8638B\\0\\0\\D"`
+	want := `Microsoft:27BBD2D0\83F8638B\0\0\D`
+	if got := extractInstanceIDFromRef(ref); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	// 素の InstanceID (golden 形式) はそのまま返す。
+	plain := `Microsoft:vm\DISK-0`
+	if got := extractInstanceIDFromRef(plain); got != plain {
+		t.Errorf("plain: got %q, want %q", got, plain)
+	}
+}
+
+// TestMapHardDiskDriveRefs_RealEPRFormat は実 Hyper-V の Parent 形式 (二重エスケープ WMI パス) で
+// storage→drive→controller の結合が成立することを検証する (Fable レビュー C1 の実機バグ回帰)。
+func TestMapHardDiskDriveRefs_RealEPRFormat(t *testing.T) {
+	vm := "27BBD2D0"
+	ctrlID := `Microsoft:27BBD2D0\SCSI\0`
+	driveID := `Microsoft:27BBD2D0\SCSI\0\0\D`
+	// Parent は WMI オブジェクトパス形式 (InstanceID 部分は \\ で二重エスケープ)。
+	toRef := func(id string) string {
+		esc := strings.ReplaceAll(id, `\`, `\\`)
+		return `\\HOST\root\virtualization\v2:Msvm_ResourceAllocationSettingData.InstanceID="` + esc + `"`
+	}
+	ctrl := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: ctrlID}
+	drive := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: driveID, Parent: toRef(ctrlID), AddressOnParent: "0"}
+	storages := []*hyperv.Msvm_StorageAllocationSettingData{
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualHardDisk, HostResource: `D:\a.vhdx`, Parent: toRef(driveID)},
+	}
+	got := mapHardDiskDriveRefs(vm, storages,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{drive}, nil,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{ctrl},
+	)
+	if len(got) != 1 {
+		t.Fatalf("実 EPR 形式で結合できていない: got %d, want 1", len(got))
+	}
+	if got[0].drive.ControllerType != api.ControllerType_Scsi || got[0].drive.Path != `D:\a.vhdx` {
+		t.Errorf("got %+v", got[0].drive)
 	}
 }
 

--- a/api/hyperv-wsman/vm_hard_disk_drive_test.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive_test.go
@@ -1,0 +1,216 @@
+package hyperv_wsman
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// TestClientConfig_ImplementsHypervVmHardDiskDriveClient は ClientConfig が
+// api.HypervVmHardDiskDriveClient を実装し、全メソッドが本パッケージで
+// シャドウイングされていることを検証する。
+func TestClientConfig_ImplementsHypervVmHardDiskDriveClient(t *testing.T) {
+	var c *ClientConfig
+	var _ api.HypervVmHardDiskDriveClient = c // コンパイル時チェック
+
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	for _, methodName := range []string{
+		"CreateVmHardDiskDrive",
+		"GetVmHardDiskDrives",
+		"UpdateVmHardDiskDrive",
+		"DeleteVmHardDiskDrive",
+		"CreateOrUpdateVmHardDiskDrives",
+	} {
+		if _, ok := cType.MethodByName(methodName); !ok {
+			t.Errorf("メソッド %s が hyperv-wsman で定義されていない (シャドウイングされない)", methodName)
+		}
+	}
+}
+
+func TestWsmanControllerType(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      api.ControllerType
+		want    hyperv.ControllerType
+		wantErr bool
+	}{
+		{"IDE", api.ControllerType_Ide, hyperv.ControllerTypeIDE, false},
+		{"SCSI", api.ControllerType_Scsi, hyperv.ControllerTypeSCSI, false},
+		{"unknown", api.ControllerType(99), "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := wsmanControllerType(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err: got %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnsupportedHardDiskOptions は既定値なら nil、既定外の未対応オプションでは error を返すこと。
+func TestUnsupportedHardDiskOptions(t *testing.T) {
+	// スキーマ既定値 = すべて「未設定」= サポート対象。
+	defaults := func() (uint32, string, bool, uint64, uint64, string, api.CacheAttributes) {
+		return hardDiskDiskNumberUnset, hardDiskDefaultPool, false, 0, 0, hardDiskZeroQosPolicyGUID, api.CacheAttributes_Default
+	}
+
+	t.Run("既定値は許可", func(t *testing.T) {
+		dn, rp, spr, maxio, minio, qos, cache := defaults()
+		if err := unsupportedHardDiskOptions(dn, rp, spr, maxio, minio, qos, cache); err != nil {
+			t.Errorf("既定値でエラー: %v", err)
+		}
+	})
+	t.Run("空のプール名も許可", func(t *testing.T) {
+		if err := unsupportedHardDiskOptions(hardDiskDiskNumberUnset, "", false, 0, 0, hardDiskZeroQosPolicyGUID, api.CacheAttributes_Default); err != nil {
+			t.Errorf("空プール名でエラー: %v", err)
+		}
+	})
+
+	unsupportedCases := []struct {
+		name  string
+		apply func(*uint32, *string, *bool, *uint64, *uint64, *string, *api.CacheAttributes)
+	}{
+		{"passthrough disk", func(dn *uint32, _ *string, _ *bool, _ *uint64, _ *uint64, _ *string, _ *api.CacheAttributes) { *dn = 3 }},
+		{"custom pool", func(_ *uint32, rp *string, _ *bool, _ *uint64, _ *uint64, _ *string, _ *api.CacheAttributes) {
+			*rp = "MyPool"
+		}},
+		{"persistent reservations", func(_ *uint32, _ *string, spr *bool, _ *uint64, _ *uint64, _ *string, _ *api.CacheAttributes) {
+			*spr = true
+		}},
+		{"max iops", func(_ *uint32, _ *string, _ *bool, maxio *uint64, _ *uint64, _ *string, _ *api.CacheAttributes) {
+			*maxio = 500
+		}},
+		{"min iops", func(_ *uint32, _ *string, _ *bool, _ *uint64, minio *uint64, _ *string, _ *api.CacheAttributes) {
+			*minio = 100
+		}},
+		{"qos policy", func(_ *uint32, _ *string, _ *bool, _ *uint64, _ *uint64, qos *string, _ *api.CacheAttributes) {
+			*qos = "11111111-0000-0000-0000-000000000000"
+		}},
+		{"cache attr", func(_ *uint32, _ *string, _ *bool, _ *uint64, _ *uint64, _ *string, cache *api.CacheAttributes) {
+			*cache = api.CacheAttributes_WriteCacheEnabled
+		}},
+	}
+	for _, tc := range unsupportedCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dn, rp, spr, maxio, minio, qos, cache := defaults()
+			tc.apply(&dn, &rp, &spr, &maxio, &minio, &qos, &cache)
+			if err := unsupportedHardDiskOptions(dn, rp, spr, maxio, minio, qos, cache); err == nil {
+				t.Errorf("%s は未対応なのでエラーになるべき", tc.name)
+			}
+		})
+	}
+}
+
+// TestMapHardDiskDriveRefs は storage→drive→controller の逆引き結合を検証する。
+func TestMapHardDiskDriveRefs(t *testing.T) {
+	vm := "11111111-aaaa-bbbb-cccc-000000000001"
+	scsiCtrl := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\SCSI-CTRL-0`}
+	ideCtrl := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\IDE-CTRL-0`}
+
+	// SCSI 位置5 の VHD と IDE 位置0 の VHD。golden 相当のデータを手組みする。
+	scsiDrive := &hyperv.Msvm_ResourceAllocationSettingData{
+		InstanceID: `Microsoft:` + vm + `\DISK-SCSI`, Parent: scsiCtrl.InstanceID, AddressOnParent: "5",
+	}
+	ideDrive := &hyperv.Msvm_ResourceAllocationSettingData{
+		InstanceID: `Microsoft:` + vm + `\DISK-IDE`, Parent: ideCtrl.InstanceID, AddressOnParent: "0",
+	}
+	storages := []*hyperv.Msvm_StorageAllocationSettingData{
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualHardDisk, HostResource: `D:\VMs\boot.vhdx`, Parent: scsiDrive.InstanceID},
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualHardDisk, HostResource: `D:\VMs\data.vhdx`, Parent: ideDrive.InstanceID},
+		// DVD/ISO は対象外 (除外されること)
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualCDDVDDisk, HostResource: `D:\ISOs\x.iso`, Parent: ideDrive.InstanceID},
+	}
+
+	got := mapHardDiskDriveRefs(vm, storages,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{scsiDrive, ideDrive},
+		[]*hyperv.Msvm_ResourceAllocationSettingData{ideCtrl},
+		[]*hyperv.Msvm_ResourceAllocationSettingData{scsiCtrl},
+	)
+
+	// VHD 2 本 (ISO 除外)。ソート順: IDE(0) が SCSI(1) より前。
+	if len(got) != 2 {
+		t.Fatalf("len: got %d, want 2 (ISO は除外)", len(got))
+	}
+	if got[0].drive.ControllerType != api.ControllerType_Ide || got[0].drive.Path != `D:\VMs\data.vhdx` {
+		t.Errorf("got[0] want IDE/data.vhdx, got %v/%q", got[0].drive.ControllerType, got[0].drive.Path)
+	}
+	if got[1].drive.ControllerType != api.ControllerType_Scsi || got[1].drive.ControllerLocation != 5 {
+		t.Errorf("got[1] want SCSI/loc5, got %v/%d", got[1].drive.ControllerType, got[1].drive.ControllerLocation)
+	}
+	if got[1].driveInstanceID != scsiDrive.InstanceID {
+		t.Errorf("driveInstanceID: got %q, want %q", got[1].driveInstanceID, scsiDrive.InstanceID)
+	}
+	// 既定値 (unset sentinel) が埋まっていること。
+	if got[0].drive.DiskNumber != hardDiskDiskNumberUnset || got[0].drive.ResourcePoolName != hardDiskDefaultPool {
+		t.Errorf("既定値が未設定: DiskNumber=%d Pool=%q", got[0].drive.DiskNumber, got[0].drive.ResourcePoolName)
+	}
+}
+
+// TestMapHardDiskDriveRefs_UnresolvedSkipped は親 Drive/Controller が特定できない storage をスキップ。
+func TestMapHardDiskDriveRefs_UnresolvedSkipped(t *testing.T) {
+	got := mapHardDiskDriveRefs("vm",
+		[]*hyperv.Msvm_StorageAllocationSettingData{
+			{ResourceSubType: hyperv.ResourceSubTypeVirtualHardDisk, HostResource: `D:\x.vhdx`, Parent: `Microsoft:vm\NO-SUCH-DRIVE`},
+		},
+		nil, nil, nil,
+	)
+	if len(got) != 0 {
+		t.Errorf("親不明の storage はスキップされるべき; got %d", len(got))
+	}
+}
+
+// TestPlanHardDiskDriveReconcile は集合差分の detach/attach 計画を検証する。
+func TestPlanHardDiskDriveReconcile(t *testing.T) {
+	mkRef := func(id string, ct api.ControllerType, num, loc int32, path string) hardDiskDriveRef {
+		return hardDiskDriveRef{
+			driveInstanceID: id,
+			drive:           api.VmHardDiskDrive{ControllerType: ct, ControllerNumber: num, ControllerLocation: loc, Path: path},
+		}
+	}
+	mkD := func(ct api.ControllerType, num, loc int32, path string) api.VmHardDiskDrive {
+		return api.VmHardDiskDrive{ControllerType: ct, ControllerNumber: num, ControllerLocation: loc, Path: path}
+	}
+
+	t.Run("変化なし = 何もしない", func(t *testing.T) {
+		cur := []hardDiskDriveRef{mkRef("d1", api.ControllerType_Scsi, 0, 0, `D:\a.vhdx`)}
+		des := []api.VmHardDiskDrive{mkD(api.ControllerType_Scsi, 0, 0, `D:\a.vhdx`)}
+		detach, attach := planHardDiskDriveReconcile(cur, des)
+		if len(detach) != 0 || len(attach) != 0 {
+			t.Errorf("変化なしのはず: detach=%v attach=%v", detach, attach)
+		}
+	})
+	t.Run("パス大小違いは同一扱い", func(t *testing.T) {
+		cur := []hardDiskDriveRef{mkRef("d1", api.ControllerType_Scsi, 0, 0, `D:\Boot.vhdx`)}
+		des := []api.VmHardDiskDrive{mkD(api.ControllerType_Scsi, 0, 0, `d:\boot.vhdx`)}
+		detach, attach := planHardDiskDriveReconcile(cur, des)
+		if len(detach) != 0 || len(attach) != 0 {
+			t.Errorf("大小違いは同一のはず: detach=%v attach=%v", detach, attach)
+		}
+	})
+	t.Run("追加と削除", func(t *testing.T) {
+		cur := []hardDiskDriveRef{mkRef("old", api.ControllerType_Ide, 0, 0, `D:\old.vhdx`)}
+		des := []api.VmHardDiskDrive{mkD(api.ControllerType_Scsi, 0, 0, `D:\new.vhdx`)}
+		detach, attach := planHardDiskDriveReconcile(cur, des)
+		if len(detach) != 1 || detach[0] != "old" {
+			t.Errorf("detach: got %v, want [old]", detach)
+		}
+		if len(attach) != 1 || attach[0].Path != `D:\new.vhdx` {
+			t.Errorf("attach: got %v", attach)
+		}
+	})
+	t.Run("Controller種別変更 = detach+attach", func(t *testing.T) {
+		// 同じパスでも IDE→SCSI の移動は key が変わるので付け替え。
+		cur := []hardDiskDriveRef{mkRef("ide0", api.ControllerType_Ide, 0, 0, `D:\boot.vhdx`)}
+		des := []api.VmHardDiskDrive{mkD(api.ControllerType_Scsi, 0, 0, `D:\boot.vhdx`)}
+		detach, attach := planHardDiskDriveReconcile(cur, des)
+		if len(detach) != 1 || len(attach) != 1 {
+			t.Errorf("種別変更は detach+attach: detach=%v attach=%v", detach, attach)
+		}
+	})
+}

--- a/api/hyperv-wsman/vm_hard_disk_drive_test.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive_test.go
@@ -257,8 +257,9 @@ func TestMapHardDiskDriveRefs_UnresolvedSkipped(t *testing.T) {
 func TestPlanHardDiskDriveReconcile(t *testing.T) {
 	mkRef := func(id string, ct api.ControllerType, num, loc int32, path string) hardDiskDriveRef {
 		return hardDiskDriveRef{
-			driveInstanceID: id,
-			drive:           api.VmHardDiskDrive{ControllerType: ct, ControllerNumber: num, ControllerLocation: loc, Path: path},
+			driveInstanceID:   id,
+			storageInstanceID: id + "-storage", // detach 計画が Storage InstanceID も運ぶことを検証する
+			drive:             api.VmHardDiskDrive{ControllerType: ct, ControllerNumber: num, ControllerLocation: loc, Path: path},
 		}
 	}
 	mkD := func(ct api.ControllerType, num, loc int32, path string) api.VmHardDiskDrive {
@@ -285,8 +286,11 @@ func TestPlanHardDiskDriveReconcile(t *testing.T) {
 		cur := []hardDiskDriveRef{mkRef("old", api.ControllerType_Ide, 0, 0, `D:\old.vhdx`)}
 		des := []api.VmHardDiskDrive{mkD(api.ControllerType_Scsi, 0, 0, `D:\new.vhdx`)}
 		detach, attach := planHardDiskDriveReconcile(cur, des)
-		if len(detach) != 1 || detach[0] != "old" {
+		if len(detach) != 1 || detach[0].driveInstanceID != "old" {
 			t.Errorf("detach: got %v, want [old]", detach)
+		}
+		if len(detach) == 1 && detach[0].storageInstanceID != "old-storage" {
+			t.Errorf("detach は Storage InstanceID も運ぶべき: got %q", detach[0].storageInstanceID)
 		}
 		if len(attach) != 1 || attach[0].Path != `D:\new.vhdx` {
 			t.Errorf("attach: got %v", attach)

--- a/api/hyperv-wsman/vm_hard_disk_drive_test.go
+++ b/api/hyperv-wsman/vm_hard_disk_drive_test.go
@@ -152,6 +152,49 @@ func TestMapHardDiskDriveRefs(t *testing.T) {
 	}
 }
 
+// TestMapHardDiskDriveRefs_ControllerOrderDeterministic は Controller 番号が列挙順でなく
+// InstanceID ソート順で決まることを検証する (H2)。列挙順が入れ替わっても番号が安定する。
+func TestMapHardDiskDriveRefs_ControllerOrderDeterministic(t *testing.T) {
+	vm := "vm1"
+	// InstanceID 昇順では A < B。あえて逆順 [B, A] で渡す。
+	ctrlA := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\SCSI-A`}
+	ctrlB := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\SCSI-B`}
+	driveOnA := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\D-A`, Parent: ctrlA.InstanceID, AddressOnParent: "0"}
+	storages := []*hyperv.Msvm_StorageAllocationSettingData{
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualHardDisk, HostResource: `D:\a.vhdx`, Parent: driveOnA.InstanceID},
+	}
+	got := mapHardDiskDriveRefs(vm, storages,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{driveOnA},
+		nil,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{ctrlB, ctrlA}, // 逆順で渡す
+	)
+	if len(got) != 1 {
+		t.Fatalf("len: got %d, want 1", len(got))
+	}
+	// ソート後 A=番号0 なので、SCSI-A の disk は ControllerNumber 0。
+	if got[0].drive.ControllerNumber != 0 {
+		t.Errorf("ControllerNumber: got %d, want 0 (InstanceID ソートで SCSI-A が先)", got[0].drive.ControllerNumber)
+	}
+}
+
+// TestMapHardDiskDriveRefs_ParseFailureSkipped は AddressOnParent がパース不能な drive を
+// スキップすることを検証する (M4、location=0 化でキー衝突を防ぐ)。
+func TestMapHardDiskDriveRefs_ParseFailureSkipped(t *testing.T) {
+	vm := "vm1"
+	ctrl := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\SCSI-0`}
+	badDrive := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\D-bad`, Parent: ctrl.InstanceID, AddressOnParent: "notanumber"}
+	storages := []*hyperv.Msvm_StorageAllocationSettingData{
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualHardDisk, HostResource: `D:\a.vhdx`, Parent: badDrive.InstanceID},
+	}
+	got := mapHardDiskDriveRefs(vm, storages,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{badDrive}, nil,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{ctrl},
+	)
+	if len(got) != 0 {
+		t.Errorf("AddressOnParent パース失敗の drive はスキップされるべき; got %d", len(got))
+	}
+}
+
 // TestMapHardDiskDriveRefs_UnresolvedSkipped は親 Drive/Controller が特定できない storage をスキップ。
 func TestMapHardDiskDriveRefs_UnresolvedSkipped(t *testing.T) {
 	got := mapHardDiskDriveRefs("vm",
@@ -211,6 +254,18 @@ func TestPlanHardDiskDriveReconcile(t *testing.T) {
 		detach, attach := planHardDiskDriveReconcile(cur, des)
 		if len(detach) != 1 || len(attach) != 1 {
 			t.Errorf("種別変更は detach+attach: detach=%v attach=%v", detach, attach)
+		}
+	})
+	// M3: チェックポイント (.avhdx) が占めるスロットは detach も attach もしない (チェーン保護)。
+	t.Run("checkpoint(.avhdx)は触らない", func(t *testing.T) {
+		cur := []hardDiskDriveRef{mkRef("chk", api.ControllerType_Scsi, 0, 0, `D:\boot_A1B2.avhdx`)}
+		des := []api.VmHardDiskDrive{mkD(api.ControllerType_Scsi, 0, 0, `D:\boot.vhdx`)}
+		detach, attach := planHardDiskDriveReconcile(cur, des)
+		if len(detach) != 0 {
+			t.Errorf("checkpoint disk は detach しないべき: detach=%v", detach)
+		}
+		if len(attach) != 0 {
+			t.Errorf("checkpoint が占めるスロットには attach しないべき: attach=%v", attach)
 		}
 	})
 }

--- a/api/hyperv-wsman/vm_network_adapter.go
+++ b/api/hyperv-wsman/vm_network_adapter.go
@@ -142,11 +142,19 @@ func (c *ClientConfig) createNetworkAdapter(ctx context.Context, a api.VmNetwork
 		ElementName: a.Name,
 		SwitchName:  a.SwitchName,
 	}
-	if !a.DynamicMacAddress && a.StaticMacAddress != "" {
+	// 静的 MAC 指定時は MAC 必須 (silent drop 禁止, M2)。区切り文字は正規化して送る。
+	if !a.DynamicMacAddress {
+		if a.StaticMacAddress == "" {
+			return fmt.Errorf("hyperv-wsman: CreateVmNetworkAdapter %q: dynamic_mac_address=false のとき static_mac_address は必須です", a.Name)
+		}
 		opts.StaticMacAddress = true
-		opts.MacAddress = a.StaticMacAddress
+		opts.MacAddress = normalizeMac(a.StaticMacAddress)
 	}
-	if _, err := c.WsmanClient.AddNetworkAdapter(ctx, a.VmName, opts); err != nil {
+	guid, err := c.resolveVMGUID(ctx, a.VmName)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmNetworkAdapter %q: %w", a.VmName, err)
+	}
+	if _, err := c.WsmanClient.AddNetworkAdapter(ctx, guid, opts); err != nil {
 		return fmt.Errorf("hyperv-wsman: CreateVmNetworkAdapter %q: %w", a.VmName, err)
 	}
 	return nil
@@ -163,11 +171,15 @@ type networkAdapterRef struct {
 // port(NIC本体: 名前・MAC) → allocation(接続先スイッチ EPR) → switch(表示名) の結合で
 // VmNetworkAdapter を復元する。削除用に Port の InstanceID も保持する。
 func (c *ClientConfig) getNetworkAdapterRefs(ctx context.Context, vmName string) ([]networkAdapterRef, error) {
-	ports, err := c.WsmanClient.ListNetworkAdapters(ctx, vmName)
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: get network adapters %q: %w", vmName, err)
+	}
+	ports, err := c.WsmanClient.ListNetworkAdapters(ctx, guid)
 	if err != nil {
 		return nil, fmt.Errorf("hyperv-wsman: list network adapters %q: %w", vmName, err)
 	}
-	allocs, err := c.WsmanClient.ListEthernetPortAllocations(ctx, vmName)
+	allocs, err := c.WsmanClient.ListEthernetPortAllocations(ctx, guid)
 	if err != nil {
 		return nil, fmt.Errorf("hyperv-wsman: list port allocations %q: %w", vmName, err)
 	}
@@ -180,8 +192,8 @@ func (c *ClientConfig) getNetworkAdapterRefs(ctx context.Context, vmName string)
 
 // GetVmNetworkAdapters は VM の NIC 一覧を返す (go-wsman 逆引き)。
 //
-// networkAdaptersWaitForIps は本経路では未使用 (ゲスト IP 取得は KVP/統合サービス依存で範囲外)。
-// IpAddresses は空で返す。
+// networkAdaptersWaitForIps の wait_for_ips は名前突合で結果に反映する (winrm 版と同じ、M1)。
+// 実際のゲスト IP 取得 (KVP/統合サービス依存) は本経路では未対応で、IpAddresses は空で返す。
 func (c *ClientConfig) GetVmNetworkAdapters(ctx context.Context, vmName string, networkAdaptersWaitForIps []api.VmNetworkAdapterWaitForIp) ([]api.VmNetworkAdapter, error) {
 	refs, err := c.getNetworkAdapterRefs(ctx, vmName)
 	if err != nil {
@@ -190,6 +202,14 @@ func (c *ClientConfig) GetVmNetworkAdapters(ctx context.Context, vmName string, 
 	result := make([]api.VmNetworkAdapter, 0, len(refs))
 	for _, r := range refs {
 		result = append(result, r.adapter)
+	}
+	// config の wait_for_ips を名前突合で反映 (未設定 NIC は既定 true のまま)。
+	for _, w := range networkAdaptersWaitForIps {
+		for i := range result {
+			if result[i].Name == w.Name {
+				result[i].WaitForIps = w.WaitForIps
+			}
+		}
 	}
 	return result, nil
 }
@@ -298,14 +318,22 @@ func networkAdapterFromParams(
 //
 // port.InstanceID を allocation.Parent と突き合わせて接続先スイッチ EPR を得、switch.Name(GUID) を
 // EPR から引いて表示名 (ElementName) に解決する。未対応フィールドは既定値で埋め、Index は順序で採番。
+//
+// 順序は ElementName でソートする (H3)。CIM に作成順を表す決定的キーが無く、port の InstanceID は
+// ランダム GUID で config 順と無相関のため、表示名順にすることでユーザーが名前で state 順を制御できる。
+// 制約: 同名 NIC が複数あると順序が一意に定まらない (同名複数 NIC は本経路では非対応、ドキュメント参照)。
 func mapNetworkAdapterRefs(
 	vmName string,
 	ports []*hyperv.Msvm_SyntheticEthernetPortSettingData,
 	allocs []*hyperv.Msvm_EthernetPortAllocationSettingData,
 	switches []*hyperv.Msvm_VirtualEthernetSwitch,
 ) []networkAdapterRef {
-	// port InstanceID を安定させるためソート。
-	sort.SliceStable(ports, func(i, j int) bool { return ports[i].InstanceID < ports[j].InstanceID })
+	sort.SliceStable(ports, func(i, j int) bool {
+		if ports[i].ElementName != ports[j].ElementName {
+			return ports[i].ElementName < ports[j].ElementName
+		}
+		return ports[i].InstanceID < ports[j].InstanceID // 同名時のタイブレーク
+	})
 
 	refs := make([]networkAdapterRef, 0, len(ports))
 	for i, p := range ports {
@@ -341,33 +369,47 @@ func resolveSwitchName(portInstanceID string, allocs []*hyperv.Msvm_EthernetPort
 	return ""
 }
 
+// normalizeMac は MAC アドレスの区切り文字 (: - . 空白) を除去して小文字化する。
+// ユーザーが "00:15:5D:.." 等で書いても Get 結果 (12桁hex) とキーが一致するようにする (M2)。
+func normalizeMac(mac string) string {
+	r := strings.NewReplacer(":", "", "-", "", ".", "", " ", "")
+	return strings.ToLower(r.Replace(mac))
+}
+
 // networkAdapterKey は NIC の同一性を (名前, スイッチ, MAC) で表す。
 func networkAdapterKey(a api.VmNetworkAdapter) string {
 	mac := "dynamic"
 	if !a.DynamicMacAddress {
-		mac = strings.ToLower(a.StaticMacAddress)
+		mac = normalizeMac(a.StaticMacAddress)
 	}
 	return fmt.Sprintf("%s/%s/%s", a.Name, strings.ToLower(a.SwitchName), mac)
 }
 
 // planNetworkAdapterReconcile は現状を所望に収束させる remove(Port InstanceID)/add 計画を返す。
+//
+// 同一キー (名前+スイッチ+MAC) の NIC が複数あり得るため multiset 差分で過不足を計算する (H1)。
+// 単純な set 差分では「現状1本・所望2本」で toAdd が空になり永遠に収束しない。
 func planNetworkAdapterReconcile(current []networkAdapterRef, desired []api.VmNetworkAdapter) (toRemove []string, toAdd []api.VmNetworkAdapter) {
-	currentKeys := make(map[string]string, len(current))
+	currentByKey := make(map[string][]string) // key → 現状 Port InstanceID 群
 	for _, r := range current {
-		currentKeys[networkAdapterKey(r.adapter)] = r.portInstanceID
+		k := networkAdapterKey(r.adapter)
+		currentByKey[k] = append(currentByKey[k], r.portInstanceID)
 	}
-	desiredKeys := make(map[string]struct{}, len(desired))
+	desiredByKey := make(map[string][]api.VmNetworkAdapter) // key → 所望 NIC 群
 	for _, d := range desired {
-		desiredKeys[networkAdapterKey(d)] = struct{}{}
+		k := networkAdapterKey(d)
+		desiredByKey[k] = append(desiredByKey[k], d)
 	}
-	for _, r := range current {
-		if _, ok := desiredKeys[networkAdapterKey(r.adapter)]; !ok {
-			toRemove = append(toRemove, r.portInstanceID)
+	// 現状が所望より多いキーは余剰分を remove。
+	for k, ports := range currentByKey {
+		for i := len(desiredByKey[k]); i < len(ports); i++ {
+			toRemove = append(toRemove, ports[i])
 		}
 	}
-	for _, d := range desired {
-		if _, ok := currentKeys[networkAdapterKey(d)]; !ok {
-			toAdd = append(toAdd, d)
+	// 所望が現状より多いキーは不足分を add。
+	for k, ds := range desiredByKey {
+		for i := len(currentByKey[k]); i < len(ds); i++ {
+			toAdd = append(toAdd, ds[i])
 		}
 	}
 	return toRemove, toAdd

--- a/api/hyperv-wsman/vm_network_adapter.go
+++ b/api/hyperv-wsman/vm_network_adapter.go
@@ -1,0 +1,374 @@
+package hyperv_wsman
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// defaultVmNetworkAdapter は network_adaptors スキーマの既定値を持つ VmNetworkAdapter を返す。
+//
+// go-wsman 経路が扱わないフィールドは、Get 結果でこの既定値を返して terraform の差分を防ぎ、
+// また Create/Update ではこの既定値以外が指定されたら未対応として拒否する基準に使う。
+func defaultVmNetworkAdapter() api.VmNetworkAdapter {
+	return api.VmNetworkAdapter{
+		ManagementOs:                           false,
+		IsLegacy:                               false,
+		DynamicMacAddress:                      true,
+		StaticMacAddress:                       "",
+		MacAddressSpoofing:                     api.OnOffState_Off,
+		DhcpGuard:                              api.OnOffState_Off,
+		RouterGuard:                            api.OnOffState_Off,
+		PortMirroring:                          api.PortMirroring_None,
+		IeeePriorityTag:                        api.OnOffState_Off,
+		VmqWeight:                              100,
+		IovQueuePairsRequested:                 1,
+		IovInterruptModeration:                 api.IovInterruptModerationValue_Off,
+		IovWeight:                              100,
+		IpsecOffloadMaximumSecurityAssociation: 512,
+		MaximumBandwidth:                       0,
+		MinimumBandwidthAbsolute:               0,
+		MinimumBandwidthWeight:                 0,
+		ResourcePoolName:                       "",
+		TestReplicaPoolName:                    "",
+		TestReplicaSwitchName:                  "",
+		VirtualSubnetId:                        0,
+		AllowTeaming:                           api.OnOffState_On,
+		NotMonitoredInCluster:                  false,
+		StormLimit:                             0,
+		DynamicIpAddressLimit:                  0,
+		DeviceNaming:                           api.OnOffState_Off,
+		FixSpeed10G:                            api.OnOffState_Off,
+		PacketDirectNumProcs:                   0,
+		PacketDirectModerationCount:            0,
+		PacketDirectModerationInterval:         0,
+		VrssEnabled:                            true,
+		VmmqEnabled:                            false,
+		VmmqQueuePairs:                         16,
+		VlanAccess:                             false,
+		VlanId:                                 0,
+		WaitForIps:                             true,
+	}
+}
+
+// unsupportedNetworkAdapterOptions は go-wsman 経路が未対応の NIC オプションが既定値以外で
+// 指定されていれば error を返す。
+//
+// go-wsman の AddNetworkAdapter は「NIC 本体 + スイッチ接続 + MAC」のみ対応する。QoS・IOV・
+// セキュリティ (spoofing/guard)・VLAN・帯域・チーミング・PacketDirect 等はまだ扱えないため、
+// silent drop を避けて明示的に拒否する (rules 準拠、これらは v2.1 以降)。
+func unsupportedNetworkAdapterOptions(a api.VmNetworkAdapter) error {
+	def := defaultVmNetworkAdapter()
+	var unsupported []string
+	add := func(cond bool, name string) {
+		if cond {
+			unsupported = append(unsupported, name)
+		}
+	}
+	add(a.ManagementOs != def.ManagementOs, "management_os")
+	add(a.IsLegacy != def.IsLegacy, "is_legacy")
+	add(a.MacAddressSpoofing != def.MacAddressSpoofing, "mac_address_spoofing")
+	add(a.DhcpGuard != def.DhcpGuard, "dhcp_guard")
+	add(a.RouterGuard != def.RouterGuard, "router_guard")
+	add(a.PortMirroring != def.PortMirroring, "port_mirroring")
+	add(a.IeeePriorityTag != def.IeeePriorityTag, "ieee_priority_tag")
+	add(a.VmqWeight != def.VmqWeight, "vmq_weight")
+	add(a.IovQueuePairsRequested != def.IovQueuePairsRequested, "iov_queue_pairs_requested")
+	add(a.IovInterruptModeration != def.IovInterruptModeration, "iov_interrupt_moderation")
+	add(a.IovWeight != def.IovWeight, "iov_weight")
+	add(a.IpsecOffloadMaximumSecurityAssociation != def.IpsecOffloadMaximumSecurityAssociation, "ipsec_offload_maximum_security_association")
+	add(a.MaximumBandwidth != def.MaximumBandwidth, "maximum_bandwidth")
+	add(a.MinimumBandwidthAbsolute != def.MinimumBandwidthAbsolute, "minimum_bandwidth_absolute")
+	add(a.MinimumBandwidthWeight != def.MinimumBandwidthWeight, "minimum_bandwidth_weight")
+	add(len(a.MandatoryFeatureId) > 0, "mandatory_feature_id")
+	add(a.ResourcePoolName != def.ResourcePoolName, "resource_pool_name")
+	add(a.TestReplicaPoolName != def.TestReplicaPoolName, "test_replica_pool_name")
+	add(a.TestReplicaSwitchName != def.TestReplicaSwitchName, "test_replica_switch_name")
+	add(a.VirtualSubnetId != def.VirtualSubnetId, "virtual_subnet_id")
+	add(a.AllowTeaming != def.AllowTeaming, "allow_teaming")
+	add(a.NotMonitoredInCluster != def.NotMonitoredInCluster, "not_monitored_in_cluster")
+	add(a.StormLimit != def.StormLimit, "storm_limit")
+	add(a.DynamicIpAddressLimit != def.DynamicIpAddressLimit, "dynamic_ip_address_limit")
+	add(a.DeviceNaming != def.DeviceNaming, "device_naming")
+	add(a.FixSpeed10G != def.FixSpeed10G, "fix_speed_10g")
+	add(a.PacketDirectNumProcs != def.PacketDirectNumProcs, "packet_direct_num_procs")
+	add(a.PacketDirectModerationCount != def.PacketDirectModerationCount, "packet_direct_moderation_count")
+	add(a.PacketDirectModerationInterval != def.PacketDirectModerationInterval, "packet_direct_moderation_interval")
+	add(a.VrssEnabled != def.VrssEnabled, "vrss_enabled")
+	add(a.VmmqEnabled != def.VmmqEnabled, "vmmq_enabled")
+	add(a.VmmqQueuePairs != def.VmmqQueuePairs, "vmmq_queue_pairs")
+	add(a.VlanAccess != def.VlanAccess, "vlan_access")
+	add(a.VlanId != def.VlanId, "vlan_id")
+
+	if len(unsupported) > 0 {
+		return fmt.Errorf(
+			"hyperv-wsman: network_adaptor のオプション %s は go-wsman 経路 (HYPERV_USE_WSMAN) では未対応です。"+
+				"PowerShell 経路 (HYPERV_USE_WSMAN 未設定) を使うか、これらを既定値にしてください",
+			strings.Join(unsupported, ", "))
+	}
+	return nil
+}
+
+// CreateVmNetworkAdapter は go-wsman 経由で NIC を追加し、指定スイッチに接続する。
+func (c *ClientConfig) CreateVmNetworkAdapter(
+	ctx context.Context, vmName, name, switchName string, managementOs, isLegacy, dynamicMacAddress bool,
+	staticMacAddress string, macAddressSpoofing, dhcpGuard, routerGuard api.OnOffState, portMirroring api.PortMirroring,
+	ieeePriorityTag api.OnOffState, vmqWeight, iovQueuePairsRequested int, iovInterruptModeration api.IovInterruptModerationValue,
+	iovWeight, ipsecOffloadMaximumSecurityAssociation, maximumBandwidth, minimumBandwidthAbsolute, minimumBandwidthWeight int,
+	mandatoryFeatureId []string, resourcePoolName, testReplicaPoolName, testReplicaSwitchName string, virtualSubnetId int,
+	allowTeaming api.OnOffState, notMonitoredInCluster bool, stormLimit, dynamicIpAddressLimit int,
+	deviceNaming, fixSpeed10G api.OnOffState, packetDirectNumProcs, packetDirectModerationCount, packetDirectModerationInterval int,
+	vrssEnabled, vmmqEnabled bool, vmmqQueuePairs int, vlanAccess bool, vlanId int,
+) error {
+	a := networkAdapterFromParams(vmName, name, switchName, managementOs, isLegacy, dynamicMacAddress, staticMacAddress,
+		macAddressSpoofing, dhcpGuard, routerGuard, portMirroring, ieeePriorityTag, vmqWeight, iovQueuePairsRequested,
+		iovInterruptModeration, iovWeight, ipsecOffloadMaximumSecurityAssociation, maximumBandwidth, minimumBandwidthAbsolute,
+		minimumBandwidthWeight, mandatoryFeatureId, resourcePoolName, testReplicaPoolName, testReplicaSwitchName, virtualSubnetId,
+		allowTeaming, notMonitoredInCluster, stormLimit, dynamicIpAddressLimit, deviceNaming, fixSpeed10G, packetDirectNumProcs,
+		packetDirectModerationCount, packetDirectModerationInterval, vrssEnabled, vmmqEnabled, vmmqQueuePairs, vlanAccess, vlanId)
+	return c.createNetworkAdapter(ctx, a)
+}
+
+// createNetworkAdapter は VmNetworkAdapter 構造体から NIC を追加する共通実装。
+func (c *ClientConfig) createNetworkAdapter(ctx context.Context, a api.VmNetworkAdapter) error {
+	if err := unsupportedNetworkAdapterOptions(a); err != nil {
+		return err
+	}
+	opts := hyperv.NetworkAdapterOptions{
+		ElementName: a.Name,
+		SwitchName:  a.SwitchName,
+	}
+	if !a.DynamicMacAddress && a.StaticMacAddress != "" {
+		opts.StaticMacAddress = true
+		opts.MacAddress = a.StaticMacAddress
+	}
+	if _, err := c.WsmanClient.AddNetworkAdapter(ctx, a.VmName, opts); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmNetworkAdapter %q: %w", a.VmName, err)
+	}
+	return nil
+}
+
+// networkAdapterRef は 1 つの NIC と、その削除に必要な Port InstanceID を束ねる。
+type networkAdapterRef struct {
+	adapter        api.VmNetworkAdapter
+	portInstanceID string // Msvm_SyntheticEthernetPortSettingData の InstanceID
+}
+
+// getNetworkAdapterRefs は VM の NIC 一覧を go-wsman の逆引きで組み立てる (順序安定)。
+//
+// port(NIC本体: 名前・MAC) → allocation(接続先スイッチ EPR) → switch(表示名) の結合で
+// VmNetworkAdapter を復元する。削除用に Port の InstanceID も保持する。
+func (c *ClientConfig) getNetworkAdapterRefs(ctx context.Context, vmName string) ([]networkAdapterRef, error) {
+	ports, err := c.WsmanClient.ListNetworkAdapters(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list network adapters %q: %w", vmName, err)
+	}
+	allocs, err := c.WsmanClient.ListEthernetPortAllocations(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list port allocations %q: %w", vmName, err)
+	}
+	switches, err := c.WsmanClient.ListVirtualEthernetSwitches(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list switches: %w", err)
+	}
+	return mapNetworkAdapterRefs(vmName, ports, allocs, switches), nil
+}
+
+// GetVmNetworkAdapters は VM の NIC 一覧を返す (go-wsman 逆引き)。
+//
+// networkAdaptersWaitForIps は本経路では未使用 (ゲスト IP 取得は KVP/統合サービス依存で範囲外)。
+// IpAddresses は空で返す。
+func (c *ClientConfig) GetVmNetworkAdapters(ctx context.Context, vmName string, networkAdaptersWaitForIps []api.VmNetworkAdapterWaitForIp) ([]api.VmNetworkAdapter, error) {
+	refs, err := c.getNetworkAdapterRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]api.VmNetworkAdapter, 0, len(refs))
+	for _, r := range refs {
+		result = append(result, r.adapter)
+	}
+	return result, nil
+}
+
+// DeleteVmNetworkAdapter は index 番目の NIC を go-wsman 経由で削除する。
+func (c *ClientConfig) DeleteVmNetworkAdapter(ctx context.Context, vmName string, index int) error {
+	refs, err := c.getNetworkAdapterRefs(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	if index < 0 || index >= len(refs) {
+		return fmt.Errorf("hyperv-wsman: DeleteVmNetworkAdapter %q: index %d out of range (VM has %d NICs)", vmName, index, len(refs))
+	}
+	if _, err := c.WsmanClient.RemoveNetworkAdapter(ctx, refs[index].portInstanceID); err != nil {
+		return fmt.Errorf("hyperv-wsman: DeleteVmNetworkAdapter %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// UpdateVmNetworkAdapter は index 番目の NIC を所望の状態に置き換える (detach+attach)。
+func (c *ClientConfig) UpdateVmNetworkAdapter(
+	ctx context.Context, vmName string, index int, name, switchName string, managementOs, isLegacy, dynamicMacAddress bool,
+	staticMacAddress string, macAddressSpoofing, dhcpGuard, routerGuard api.OnOffState, portMirroring api.PortMirroring,
+	ieeePriorityTag api.OnOffState, vmqWeight, iovQueuePairsRequested int, iovInterruptModeration api.IovInterruptModerationValue,
+	iovWeight, ipsecOffloadMaximumSecurityAssociation, maximumBandwidth, minimumBandwidthAbsolute, minimumBandwidthWeight int,
+	mandatoryFeatureId []string, resourcePoolName, testReplicaPoolName, testReplicaSwitchName string, virtualSubnetId int,
+	allowTeaming api.OnOffState, notMonitoredInCluster bool, stormLimit, dynamicIpAddressLimit int,
+	deviceNaming, fixSpeed10G api.OnOffState, packetDirectNumProcs, packetDirectModerationCount, packetDirectModerationInterval int,
+	vrssEnabled, vmmqEnabled bool, vmmqQueuePairs int, vlanAccess bool, vlanId int,
+) error {
+	a := networkAdapterFromParams(vmName, name, switchName, managementOs, isLegacy, dynamicMacAddress, staticMacAddress,
+		macAddressSpoofing, dhcpGuard, routerGuard, portMirroring, ieeePriorityTag, vmqWeight, iovQueuePairsRequested,
+		iovInterruptModeration, iovWeight, ipsecOffloadMaximumSecurityAssociation, maximumBandwidth, minimumBandwidthAbsolute,
+		minimumBandwidthWeight, mandatoryFeatureId, resourcePoolName, testReplicaPoolName, testReplicaSwitchName, virtualSubnetId,
+		allowTeaming, notMonitoredInCluster, stormLimit, dynamicIpAddressLimit, deviceNaming, fixSpeed10G, packetDirectNumProcs,
+		packetDirectModerationCount, packetDirectModerationInterval, vrssEnabled, vmmqEnabled, vmmqQueuePairs, vlanAccess, vlanId)
+	if err := unsupportedNetworkAdapterOptions(a); err != nil {
+		return err
+	}
+	if err := c.DeleteVmNetworkAdapter(ctx, vmName, index); err != nil {
+		return err
+	}
+	return c.createNetworkAdapter(ctx, a)
+}
+
+// CreateOrUpdateVmNetworkAdapters は所望の NIC 集合に収束させる (集合差分、冪等)。
+func (c *ClientConfig) CreateOrUpdateVmNetworkAdapters(ctx context.Context, vmName string, networkAdapters []api.VmNetworkAdapter) error {
+	for _, a := range networkAdapters {
+		if err := unsupportedNetworkAdapterOptions(a); err != nil {
+			return err
+		}
+	}
+	current, err := c.getNetworkAdapterRefs(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	toRemove, toAdd := planNetworkAdapterReconcile(current, networkAdapters)
+	for _, portInstanceID := range toRemove {
+		if _, err := c.WsmanClient.RemoveNetworkAdapter(ctx, portInstanceID); err != nil {
+			return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmNetworkAdapters %q: remove: %w", vmName, err)
+		}
+	}
+	for _, a := range toAdd {
+		a.VmName = vmName
+		if err := c.createNetworkAdapter(ctx, a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WaitForVmNetworkAdaptersIps は go-wsman 経路では未実装のため PowerShell 実装にフォールバックする。
+// (ゲスト IP 取得は KVP/統合サービス依存。埋め込んだ hyperv_winrm.ClientConfig が処理する。)
+// —— 明示定義しないことで promotion による PowerShell フォールバックを効かせる。
+
+// --- 純関数 (table-driven test 対象) ---
+
+// networkAdapterFromParams は Create/Update の引数列を VmNetworkAdapter に詰める。
+func networkAdapterFromParams(
+	vmName, name, switchName string, managementOs, isLegacy, dynamicMacAddress bool, staticMacAddress string,
+	macAddressSpoofing, dhcpGuard, routerGuard api.OnOffState, portMirroring api.PortMirroring, ieeePriorityTag api.OnOffState,
+	vmqWeight, iovQueuePairsRequested int, iovInterruptModeration api.IovInterruptModerationValue,
+	iovWeight, ipsecOffloadMaximumSecurityAssociation, maximumBandwidth, minimumBandwidthAbsolute, minimumBandwidthWeight int,
+	mandatoryFeatureId []string, resourcePoolName, testReplicaPoolName, testReplicaSwitchName string, virtualSubnetId int,
+	allowTeaming api.OnOffState, notMonitoredInCluster bool, stormLimit, dynamicIpAddressLimit int,
+	deviceNaming, fixSpeed10G api.OnOffState, packetDirectNumProcs, packetDirectModerationCount, packetDirectModerationInterval int,
+	vrssEnabled, vmmqEnabled bool, vmmqQueuePairs int, vlanAccess bool, vlanId int,
+) api.VmNetworkAdapter {
+	return api.VmNetworkAdapter{
+		VmName: vmName, Name: name, SwitchName: switchName, ManagementOs: managementOs, IsLegacy: isLegacy,
+		DynamicMacAddress: dynamicMacAddress, StaticMacAddress: staticMacAddress, MacAddressSpoofing: macAddressSpoofing,
+		DhcpGuard: dhcpGuard, RouterGuard: routerGuard, PortMirroring: portMirroring, IeeePriorityTag: ieeePriorityTag,
+		VmqWeight: vmqWeight, IovQueuePairsRequested: iovQueuePairsRequested, IovInterruptModeration: iovInterruptModeration,
+		IovWeight: iovWeight, IpsecOffloadMaximumSecurityAssociation: ipsecOffloadMaximumSecurityAssociation,
+		MaximumBandwidth: maximumBandwidth, MinimumBandwidthAbsolute: minimumBandwidthAbsolute, MinimumBandwidthWeight: minimumBandwidthWeight,
+		MandatoryFeatureId: mandatoryFeatureId, ResourcePoolName: resourcePoolName, TestReplicaPoolName: testReplicaPoolName,
+		TestReplicaSwitchName: testReplicaSwitchName, VirtualSubnetId: virtualSubnetId, AllowTeaming: allowTeaming,
+		NotMonitoredInCluster: notMonitoredInCluster, StormLimit: stormLimit, DynamicIpAddressLimit: dynamicIpAddressLimit,
+		DeviceNaming: deviceNaming, FixSpeed10G: fixSpeed10G, PacketDirectNumProcs: packetDirectNumProcs,
+		PacketDirectModerationCount: packetDirectModerationCount, PacketDirectModerationInterval: packetDirectModerationInterval,
+		VrssEnabled: vrssEnabled, VmmqEnabled: vmmqEnabled, VmmqQueuePairs: vmmqQueuePairs, VlanAccess: vlanAccess, VlanId: vlanId,
+	}
+}
+
+// mapNetworkAdapterRefs は port/allocation/switch を結合して VmNetworkAdapter を復元する。
+//
+// port.InstanceID を allocation.Parent と突き合わせて接続先スイッチ EPR を得、switch.Name(GUID) を
+// EPR から引いて表示名 (ElementName) に解決する。未対応フィールドは既定値で埋め、Index は順序で採番。
+func mapNetworkAdapterRefs(
+	vmName string,
+	ports []*hyperv.Msvm_SyntheticEthernetPortSettingData,
+	allocs []*hyperv.Msvm_EthernetPortAllocationSettingData,
+	switches []*hyperv.Msvm_VirtualEthernetSwitch,
+) []networkAdapterRef {
+	// port InstanceID を安定させるためソート。
+	sort.SliceStable(ports, func(i, j int) bool { return ports[i].InstanceID < ports[j].InstanceID })
+
+	refs := make([]networkAdapterRef, 0, len(ports))
+	for i, p := range ports {
+		a := defaultVmNetworkAdapter()
+		a.VmName = vmName
+		a.Index = i
+		a.Name = p.ElementName
+		a.DynamicMacAddress = !p.StaticMacAddress
+		if p.StaticMacAddress {
+			a.StaticMacAddress = p.Address
+		}
+		// 接続先スイッチを allocation 経由で解決する。
+		if switchName := resolveSwitchName(p.InstanceID, allocs, switches); switchName != "" {
+			a.SwitchName = switchName
+		}
+		refs = append(refs, networkAdapterRef{adapter: a, portInstanceID: p.InstanceID})
+	}
+	return refs
+}
+
+// resolveSwitchName は port に紐づく allocation を辿り、接続先スイッチの表示名を返す (無ければ空)。
+func resolveSwitchName(portInstanceID string, allocs []*hyperv.Msvm_EthernetPortAllocationSettingData, switches []*hyperv.Msvm_VirtualEthernetSwitch) string {
+	for _, alloc := range allocs {
+		if alloc.Parent == "" || !strings.Contains(alloc.Parent, portInstanceID) {
+			continue
+		}
+		for _, sw := range switches {
+			if sw.Name != "" && strings.Contains(alloc.HostResource, sw.Name) {
+				return sw.ElementName
+			}
+		}
+	}
+	return ""
+}
+
+// networkAdapterKey は NIC の同一性を (名前, スイッチ, MAC) で表す。
+func networkAdapterKey(a api.VmNetworkAdapter) string {
+	mac := "dynamic"
+	if !a.DynamicMacAddress {
+		mac = strings.ToLower(a.StaticMacAddress)
+	}
+	return fmt.Sprintf("%s/%s/%s", a.Name, strings.ToLower(a.SwitchName), mac)
+}
+
+// planNetworkAdapterReconcile は現状を所望に収束させる remove(Port InstanceID)/add 計画を返す。
+func planNetworkAdapterReconcile(current []networkAdapterRef, desired []api.VmNetworkAdapter) (toRemove []string, toAdd []api.VmNetworkAdapter) {
+	currentKeys := make(map[string]string, len(current))
+	for _, r := range current {
+		currentKeys[networkAdapterKey(r.adapter)] = r.portInstanceID
+	}
+	desiredKeys := make(map[string]struct{}, len(desired))
+	for _, d := range desired {
+		desiredKeys[networkAdapterKey(d)] = struct{}{}
+	}
+	for _, r := range current {
+		if _, ok := desiredKeys[networkAdapterKey(r.adapter)]; !ok {
+			toRemove = append(toRemove, r.portInstanceID)
+		}
+	}
+	for _, d := range desired {
+		if _, ok := currentKeys[networkAdapterKey(d)]; !ok {
+			toAdd = append(toAdd, d)
+		}
+	}
+	return toRemove, toAdd
+}

--- a/api/hyperv-wsman/vm_network_adapter.go
+++ b/api/hyperv-wsman/vm_network_adapter.go
@@ -355,9 +355,13 @@ func mapNetworkAdapterRefs(
 }
 
 // resolveSwitchName は port に紐づく allocation を辿り、接続先スイッチの表示名を返す (無ければ空)。
+//
+// alloc.Parent は WMI オブジェクトパス (InstanceID 二重エスケープ) のため extractInstanceIDFromRef で
+// 正規化してから port と突き合わせる。スイッチ側は Name(GUID、バックスラッシュ無し) が HostResource
+// に含まれるかで判定する。
 func resolveSwitchName(portInstanceID string, allocs []*hyperv.Msvm_EthernetPortAllocationSettingData, switches []*hyperv.Msvm_VirtualEthernetSwitch) string {
 	for _, alloc := range allocs {
-		if alloc.Parent == "" || !strings.Contains(alloc.Parent, portInstanceID) {
+		if extractInstanceIDFromRef(alloc.Parent) != portInstanceID {
 			continue
 		}
 		for _, sw := range switches {

--- a/api/hyperv-wsman/vm_network_adapter_test.go
+++ b/api/hyperv-wsman/vm_network_adapter_test.go
@@ -174,4 +174,59 @@ func TestPlanNetworkAdapterReconcile(t *testing.T) {
 			t.Errorf("add: got %v", add)
 		}
 	})
+	// H1: 同一キー (同名+同スイッチ+dynamic) が複数あっても multiset で過不足を計算する。
+	t.Run("同一キー1本→2本 = add1", func(t *testing.T) {
+		cur := []networkAdapterRef{mkRef("p1", "eth0", "vSwitch")}
+		des := []api.VmNetworkAdapter{mkD("eth0", "vSwitch"), mkD("eth0", "vSwitch")}
+		rm, add := planNetworkAdapterReconcile(cur, des)
+		if len(rm) != 0 || len(add) != 1 {
+			t.Errorf("1本→2本は add1 のはず: rm=%v add=%d", rm, len(add))
+		}
+	})
+	t.Run("同一キー2本→1本 = remove1", func(t *testing.T) {
+		cur := []networkAdapterRef{mkRef("p1", "eth0", "vSwitch"), mkRef("p2", "eth0", "vSwitch")}
+		des := []api.VmNetworkAdapter{mkD("eth0", "vSwitch")}
+		rm, add := planNetworkAdapterReconcile(cur, des)
+		if len(rm) != 1 || len(add) != 0 {
+			t.Errorf("2本→1本は remove1 のはず: rm=%d add=%v", len(rm), add)
+		}
+	})
+}
+
+// TestNormalizeMac_KeyEquivalence は MAC 区切り形式の違いが同一キーになることを検証する (M2)。
+func TestNormalizeMac_KeyEquivalence(t *testing.T) {
+	mk := func(mac string) api.VmNetworkAdapter {
+		a := defaultVmNetworkAdapter()
+		a.Name, a.SwitchName = "eth0", "vSwitch"
+		a.DynamicMacAddress = false
+		a.StaticMacAddress = mac
+		return a
+	}
+	formats := []string{"00:15:5D:00:11:22", "00-15-5D-00-11-22", "00155D001122", "00155d001122"}
+	want := networkAdapterKey(mk(formats[0]))
+	for _, f := range formats[1:] {
+		if got := networkAdapterKey(mk(f)); got != want {
+			t.Errorf("MAC %q のキーが不一致: got %q want %q", f, got, want)
+		}
+	}
+}
+
+// TestMapNetworkAdapterRefs_ElementNameOrder は NIC が ElementName 順に並ぶことを検証する (H3)。
+func TestMapNetworkAdapterRefs_ElementNameOrder(t *testing.T) {
+	vm := "vm1"
+	// InstanceID 順では zzz が aaa より後だが、ElementName 順で並べたい。
+	ports := []*hyperv.Msvm_SyntheticEthernetPortSettingData{
+		{InstanceID: `Microsoft:` + vm + `\aaa`, ElementName: "zeta"},
+		{InstanceID: `Microsoft:` + vm + `\zzz`, ElementName: "alpha"},
+	}
+	got := mapNetworkAdapterRefs(vm, ports, nil, nil)
+	if len(got) != 2 {
+		t.Fatalf("len: got %d, want 2", len(got))
+	}
+	if got[0].adapter.Name != "alpha" || got[1].adapter.Name != "zeta" {
+		t.Errorf("ElementName 順のはず: got [%s, %s]", got[0].adapter.Name, got[1].adapter.Name)
+	}
+	if got[0].adapter.Index != 0 || got[1].adapter.Index != 1 {
+		t.Errorf("Index が順序どおりでない")
+	}
 }

--- a/api/hyperv-wsman/vm_network_adapter_test.go
+++ b/api/hyperv-wsman/vm_network_adapter_test.go
@@ -1,0 +1,177 @@
+package hyperv_wsman
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// TestClientConfig_ImplementsHypervVmNetworkAdapterClient は ClientConfig が
+// api.HypervVmNetworkAdapterClient を実装することを検証する。
+//
+// CreateVmNetworkAdapter/GetVmNetworkAdapters/UpdateVmNetworkAdapter/DeleteVmNetworkAdapter/
+// CreateOrUpdateVmNetworkAdapters は本パッケージでシャドウイングする。
+// WaitForVmNetworkAdaptersIps は未実装で PowerShell にフォールバックする (意図的)。
+func TestClientConfig_ImplementsHypervVmNetworkAdapterClient(t *testing.T) {
+	var c *ClientConfig
+	var _ api.HypervVmNetworkAdapterClient = c // コンパイル時チェック
+
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	for _, methodName := range []string{
+		"CreateVmNetworkAdapter",
+		"GetVmNetworkAdapters",
+		"UpdateVmNetworkAdapter",
+		"DeleteVmNetworkAdapter",
+		"CreateOrUpdateVmNetworkAdapters",
+	} {
+		if _, ok := cType.MethodByName(methodName); !ok {
+			t.Errorf("メソッド %s が hyperv-wsman で定義されていない (シャドウイングされない)", methodName)
+		}
+	}
+}
+
+// TestUnsupportedNetworkAdapterOptions は既定 NIC は許可、未対応フィールドが既定外なら error。
+func TestUnsupportedNetworkAdapterOptions(t *testing.T) {
+	base := func() api.VmNetworkAdapter {
+		a := defaultVmNetworkAdapter()
+		a.Name = "eth0"
+		a.SwitchName = "vSwitch"
+		return a
+	}
+
+	t.Run("既定 + 名前/スイッチ/動的MACは許可", func(t *testing.T) {
+		if err := unsupportedNetworkAdapterOptions(base()); err != nil {
+			t.Errorf("基本 NIC でエラー: %v", err)
+		}
+	})
+	t.Run("静的MACは許可", func(t *testing.T) {
+		a := base()
+		a.DynamicMacAddress = false
+		a.StaticMacAddress = "00155D001122"
+		if err := unsupportedNetworkAdapterOptions(a); err != nil {
+			t.Errorf("静的MACでエラー: %v", err)
+		}
+	})
+
+	cases := []struct {
+		name  string
+		apply func(*api.VmNetworkAdapter)
+	}{
+		{"management_os", func(a *api.VmNetworkAdapter) { a.ManagementOs = true }},
+		{"is_legacy", func(a *api.VmNetworkAdapter) { a.IsLegacy = true }},
+		{"mac_address_spoofing", func(a *api.VmNetworkAdapter) { a.MacAddressSpoofing = api.OnOffState_On }},
+		{"port_mirroring", func(a *api.VmNetworkAdapter) { a.PortMirroring = api.PortMirroring(2) }},
+		{"vmq_weight", func(a *api.VmNetworkAdapter) { a.VmqWeight = 0 }},
+		{"iov_queue_pairs", func(a *api.VmNetworkAdapter) { a.IovQueuePairsRequested = 4 }},
+		{"iov_weight", func(a *api.VmNetworkAdapter) { a.IovWeight = 0 }},
+		{"maximum_bandwidth", func(a *api.VmNetworkAdapter) { a.MaximumBandwidth = 1000 }},
+		{"allow_teaming", func(a *api.VmNetworkAdapter) { a.AllowTeaming = api.OnOffState_Off }},
+		{"vrss_enabled", func(a *api.VmNetworkAdapter) { a.VrssEnabled = false }},
+		{"vmmq_queue_pairs", func(a *api.VmNetworkAdapter) { a.VmmqQueuePairs = 8 }},
+		{"vlan_access", func(a *api.VmNetworkAdapter) { a.VlanAccess = true }},
+		{"mandatory_feature_id", func(a *api.VmNetworkAdapter) { a.MandatoryFeatureId = []string{"x"} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := base()
+			tc.apply(&a)
+			if err := unsupportedNetworkAdapterOptions(a); err == nil {
+				t.Errorf("%s は未対応なのでエラーになるべき", tc.name)
+			}
+		})
+	}
+}
+
+// TestMapNetworkAdapterRefs は port→allocation→switch の逆引き結合を検証する。
+func TestMapNetworkAdapterRefs(t *testing.T) {
+	vm := "11111111-aaaa-bbbb-cccc-000000000001"
+	portID := `Microsoft:` + vm + `\NIC-001`
+	switchGUID := "aaaaaaaa-1111-2222-3333-444444444444"
+
+	ports := []*hyperv.Msvm_SyntheticEthernetPortSettingData{
+		{InstanceID: portID, ElementName: "eth0", StaticMacAddress: false, Address: "00155D012345"},
+	}
+	allocs := []*hyperv.Msvm_EthernetPortAllocationSettingData{
+		{Parent: portID, HostResource: `Microsoft:VirtualSwitch\` + switchGUID},
+	}
+	switches := []*hyperv.Msvm_VirtualEthernetSwitch{
+		{Name: switchGUID, ElementName: "vSwitch-Lab"},
+	}
+
+	got := mapNetworkAdapterRefs(vm, ports, allocs, switches)
+	if len(got) != 1 {
+		t.Fatalf("len: got %d, want 1", len(got))
+	}
+	a := got[0].adapter
+	if a.Name != "eth0" {
+		t.Errorf("Name: %q", a.Name)
+	}
+	if a.SwitchName != "vSwitch-Lab" {
+		t.Errorf("SwitchName: got %q, want vSwitch-Lab (allocation→switch 解決)", a.SwitchName)
+	}
+	if !a.DynamicMacAddress {
+		t.Errorf("DynamicMacAddress should be true (StaticMacAddress=false)")
+	}
+	if a.Index != 0 {
+		t.Errorf("Index: %d", a.Index)
+	}
+	if got[0].portInstanceID != portID {
+		t.Errorf("portInstanceID: %q", got[0].portInstanceID)
+	}
+	// 未対応フィールドが既定値で埋まっていること (差分防止)。
+	if a.VmqWeight != 100 || a.AllowTeaming != api.OnOffState_On || !a.VrssEnabled {
+		t.Errorf("既定値が未反映: VmqWeight=%d AllowTeaming=%d Vrss=%v", a.VmqWeight, a.AllowTeaming, a.VrssEnabled)
+	}
+}
+
+func TestResolveSwitchName(t *testing.T) {
+	portID := `Microsoft:vm\NIC-1`
+	guid := "gg-1111"
+	allocs := []*hyperv.Msvm_EthernetPortAllocationSettingData{
+		{Parent: portID, HostResource: `Microsoft:VirtualSwitch\` + guid},
+	}
+	switches := []*hyperv.Msvm_VirtualEthernetSwitch{{Name: guid, ElementName: "Lab"}}
+
+	if got := resolveSwitchName(portID, allocs, switches); got != "Lab" {
+		t.Errorf("解決: got %q, want Lab", got)
+	}
+	// 接続なし (allocation が別 NIC) → 空。
+	if got := resolveSwitchName(`Microsoft:vm\NIC-OTHER`, allocs, switches); got != "" {
+		t.Errorf("未接続は空のはず: got %q", got)
+	}
+}
+
+func TestPlanNetworkAdapterReconcile(t *testing.T) {
+	mkRef := func(id, name, sw string) networkAdapterRef {
+		a := defaultVmNetworkAdapter()
+		a.Name, a.SwitchName = name, sw
+		return networkAdapterRef{adapter: a, portInstanceID: id}
+	}
+	mkD := func(name, sw string) api.VmNetworkAdapter {
+		a := defaultVmNetworkAdapter()
+		a.Name, a.SwitchName = name, sw
+		return a
+	}
+
+	t.Run("変化なし", func(t *testing.T) {
+		cur := []networkAdapterRef{mkRef("p1", "eth0", "vSwitch")}
+		des := []api.VmNetworkAdapter{mkD("eth0", "vSwitch")}
+		rm, add := planNetworkAdapterReconcile(cur, des)
+		if len(rm) != 0 || len(add) != 0 {
+			t.Errorf("変化なしのはず: rm=%v add=%v", rm, add)
+		}
+	})
+	t.Run("スイッチ付け替え = remove+add", func(t *testing.T) {
+		cur := []networkAdapterRef{mkRef("p1", "eth0", "old")}
+		des := []api.VmNetworkAdapter{mkD("eth0", "new")}
+		rm, add := planNetworkAdapterReconcile(cur, des)
+		if len(rm) != 1 || rm[0] != "p1" {
+			t.Errorf("remove: got %v, want [p1]", rm)
+		}
+		if len(add) != 1 || add[0].SwitchName != "new" {
+			t.Errorf("add: got %v", add)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260702162944-a2768466f9be
+	github.com/r4sd/go-wsman v0.0.0-20260702164644-fd4f67a35832
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260621112911-a6cc484373e0
+	github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260702160816-f2d010b75268
+	github.com/r4sd/go-wsman v0.0.0-20260702162944-a2768466f9be
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8
+	github.com/r4sd/go-wsman v0.0.0-20260702160816-f2d010b75268
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260702164644-fd4f67a35832
+	github.com/r4sd/go-wsman v0.0.0-20260703173240-4d36687fbf06
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260703173240-4d36687fbf06
+	github.com/r4sd/go-wsman v0.0.0-20260704091054-6f80bb555148
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,12 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260630124222-379bdb77fc8c h1:GdrRwRFq4/8AQiuF7PY5UfUPCzH+nB11BITQsaAGCAI=
-github.com/r4sd/go-wsman v0.0.0-20260630124222-379bdb77fc8c/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
-github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8 h1:7NfnE6cyUwNMODcVOls5KP1OrPKwYwusSi+HnGAIOmY=
-github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
-github.com/r4sd/go-wsman v0.0.0-20260702160816-f2d010b75268 h1:eWXrb6+Qa1WsK/q4pMjdR3IXqPHrjzJ776ntaLP+Pzg=
-github.com/r4sd/go-wsman v0.0.0-20260702160816-f2d010b75268/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260702162944-a2768466f9be h1:yB0L2p/msBWFsJC0cIgnC3Rwnexf4kdw/WDZD/NJrfY=
+github.com/r4sd/go-wsman v0.0.0-20260702162944-a2768466f9be/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260621112911-a6cc484373e0 h1:8SqbZxg7ZFrHbGv9Upeu3Rn/CUa8npMOIFHN2/5Sc2Q=
-github.com/r4sd/go-wsman v0.0.0-20260621112911-a6cc484373e0/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260630124222-379bdb77fc8c h1:GdrRwRFq4/8AQiuF7PY5UfUPCzH+nB11BITQsaAGCAI=
+github.com/r4sd/go-wsman v0.0.0-20260630124222-379bdb77fc8c/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8 h1:7NfnE6cyUwNMODcVOls5KP1OrPKwYwusSi+HnGAIOmY=
+github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260703173240-4d36687fbf06 h1:xRST74pO+cxNCOgXhWsCOA1Rx3gIXPb80onxfkaLSoI=
-github.com/r4sd/go-wsman v0.0.0-20260703173240-4d36687fbf06/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260704091054-6f80bb555148 h1:GgUE1HN/yRmPCv3H76lXeGg+motIO2F32gUI2/zry9U=
+github.com/r4sd/go-wsman v0.0.0-20260704091054-6f80bb555148/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260702162944-a2768466f9be h1:yB0L2p/msBWFsJC0cIgnC3Rwnexf4kdw/WDZD/NJrfY=
-github.com/r4sd/go-wsman v0.0.0-20260702162944-a2768466f9be/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260702164644-fd4f67a35832 h1:b73RZCwlpkdXTwUlwcRW4ZEmVoHCgBF4maqq9W5puwQ=
+github.com/r4sd/go-wsman v0.0.0-20260702164644-fd4f67a35832/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260702164644-fd4f67a35832 h1:b73RZCwlpkdXTwUlwcRW4ZEmVoHCgBF4maqq9W5puwQ=
-github.com/r4sd/go-wsman v0.0.0-20260702164644-fd4f67a35832/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260703173240-4d36687fbf06 h1:xRST74pO+cxNCOgXhWsCOA1Rx3gIXPb80onxfkaLSoI=
+github.com/r4sd/go-wsman v0.0.0-20260703173240-4d36687fbf06/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/r4sd/go-wsman v0.0.0-20260630124222-379bdb77fc8c h1:GdrRwRFq4/8AQiuF7
 github.com/r4sd/go-wsman v0.0.0-20260630124222-379bdb77fc8c/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8 h1:7NfnE6cyUwNMODcVOls5KP1OrPKwYwusSi+HnGAIOmY=
 github.com/r4sd/go-wsman v0.0.0-20260702141519-c812d6a7d9c8/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260702160816-f2d010b75268 h1:eWXrb6+Qa1WsK/q4pMjdR3IXqPHrjzJ776ntaLP+Pzg=
+github.com/r4sd/go-wsman v0.0.0-20260702160816-f2d010b75268/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/disk_nic_read_integration_test.go
+++ b/internal/provider/disk_nic_read_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の disk/nic 読み取り (#63 B) の実機統合テスト。
+//
+// provider 層の GetVmHardDiskDrives / GetVmNetworkAdapters を「VM 表示名」で呼び、
+// 実 VM のディスク/NIC が返ることを確認する (非破壊、既存 VM への読み取りのみ)。
+//
+// 目的は Fable レビューが指摘した C1 (表示名→GUID 解決) の実機検証。go-wsman の vmName は
+// GUID 契約のため、表示名を直渡ししていた旧実装では silent に 0 件を返していた。
+// 本テストで「表示名で呼んで disk が返る」= resolveVMGUID が効いていることを確認する。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	HYPERV_TEST_TARGET_VM_NAME=k8s-worker-01 \
+//	go test -tags integration ./internal/provider/ -run TestRealHostDiskNicReadWsman -v
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostDiskNicReadWsman(t *testing.T) {
+	vmName := os.Getenv("HYPERV_TEST_TARGET_VM_NAME")
+	if vmName == "" {
+		t.Skip("HYPERV_TEST_TARGET_VM_NAME 未設定 (読み取り対象の既存 VM 表示名)")
+	}
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	ctx := context.Background()
+
+	// C1 検証: 表示名で disk が解決・取得できること (旧実装は GUID 契約違反で silent 0 件)。
+	disks, err := cc.GetVmHardDiskDrives(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmHardDiskDrives(%q): %v", vmName, err)
+	}
+	t.Logf("VM %q: HardDiskDrives = %d", vmName, len(disks))
+	for i, d := range disks {
+		t.Logf("  disk[%d] type=%s ctrl=%d/%d path=%s", i, d.ControllerType, d.ControllerNumber, d.ControllerLocation, d.Path)
+	}
+	if len(disks) == 0 {
+		t.Errorf("表示名で HardDiskDrives が 0 件 = C1 (表示名→GUID 解決) が効いていない疑い")
+	}
+
+	// NIC も同様に表示名で解決・取得できること。
+	nics, err := cc.GetVmNetworkAdapters(ctx, vmName, nil)
+	if err != nil {
+		t.Fatalf("GetVmNetworkAdapters(%q): %v", vmName, err)
+	}
+	t.Logf("VM %q: NetworkAdapters = %d", vmName, len(nics))
+	for i, n := range nics {
+		t.Logf("  nic[%d] name=%q switch=%q", i, n.Name, n.SwitchName)
+	}
+}

--- a/internal/provider/disk_write_integration_test.go
+++ b/internal/provider/disk_write_integration_test.go
@@ -117,6 +117,20 @@ func TestRealHostScsiDiskWriteWsman(t *testing.T) {
 	if got[0].Path != vhdPath {
 		t.Errorf("Path: got %q, want %q", got[0].Path, vhdPath)
 	}
-	// detach (DeleteVmHardDiskDrive) は go-wsman #97 (Drive 削除が実機 0x80041001) 解消後に検証する。
-	// VM の後始末は t.Cleanup の DeleteVm が担う (VM ごと消せば disk も消える)。
+
+	// 5. detach 検証 (#97): DeleteVmHardDiskDrive で Storage→Drive の 2 段削除を行い、
+	//    逆引き Get が 0 本になることを確認する。子 SASD を残したまま Drive を消すと
+	//    実機は 0x80041001 で失敗するため、ここが通れば 2 段削除が正しいことの実証になる。
+	if err := cc.DeleteVmHardDiskDrive(ctx, vmName, 0); err != nil {
+		t.Fatalf("DeleteVmHardDiskDrive: %v", err)
+	}
+	after, err := cc.GetVmHardDiskDrives(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmHardDiskDrives (detach 後): %v", err)
+	}
+	t.Logf("detach 後: disks=%d", len(after))
+	if len(after) != 0 {
+		t.Fatalf("detach 後は 0 本のはず, got %d", len(after))
+	}
+	// VM の後始末は t.Cleanup の DeleteVm が担う (VHD ファイルは CIM では消せず残留)。
 }

--- a/internal/provider/disk_write_integration_test.go
+++ b/internal/provider/disk_write_integration_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の SCSI ディスク write 経路 (#63 B) の実機統合テスト。
+//
+// 使い捨て Gen2 VM を作り、go-wsman #89 修正で動くようになった CreateVirtualHardDisk で VHD を
+// 作成、provider の CreateOrUpdateVmHardDiskDrives (表示名→resolveVMGUID→ensureScsiController→
+// AttachVHD) で SCSI にアタッチ、GetVmHardDiskDrives の逆引きで検証、DeleteVmHardDiskDrive で
+// デタッチまで一周する。稼働中 VM は触らない。go-wsman は CIM 専用でファイル削除できないため
+// 作成した VHD は残留する (パスをログ出力)。HYPERV_TEST_ALLOW_MUTATION=1 で有効。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	HYPERV_TEST_ALLOW_MUTATION=1 \
+//	go test -tags integration ./internal/provider/ -run TestRealHostScsiDiskWriteWsman -v
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	gowsman "github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostScsiDiskWriteWsman(t *testing.T) {
+	if os.Getenv("HYPERV_TEST_ALLOW_MUTATION") == "" {
+		t.Skip("HYPERV_TEST_ALLOW_MUTATION 未設定（VM/VHD 作成を伴う破壊的テスト）")
+	}
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	ctx := context.Background()
+
+	const vmName = "tf-wsman-scsi-write-test"
+	vhdDir := os.Getenv("HYPERV_TEST_VHD_DIR")
+	if vhdDir == "" {
+		vhdDir = `D:\Hyper-V`
+	}
+	vhdPath := fmt.Sprintf(`%s\tf-wsman-scsi-write-%d.vhdx`, vhdDir, time.Now().UnixNano())
+
+	// 前回残骸を消し、テスト後は VM を確実に削除 (VHD ファイルは残留)。
+	_ = cc.DeleteVm(ctx, vmName)
+	t.Cleanup(func() {
+		if err := cc.DeleteVm(ctx, vmName); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+
+	// 1. 使い捨て Gen2 VM を実体化 (provider の CreateVm。メモリ/CPU/世代を持つ)。
+	const memByt = 536870912 // 512 MiB
+	if err := cc.CreateVm(ctx, vmName,
+		"", 2, // path(既定), generation=2(Gen2)
+		api.CriticalErrorAction_Pause, 0,
+		api.StartAction_Nothing, 0,
+		api.StopAction_Save,
+		api.CheckpointType_Production,
+		false, false, 0,
+		api.OnOffState_Off, 0,
+		memByt, memByt, memByt,
+		"scsi-write-test", 1,
+		"", "", true, false,
+	); err != nil {
+		t.Fatalf("CreateVm: %v", err)
+	}
+
+	// 2. VHD 作成 (#89 修正で実機動作)。
+	if _, err := wsmanClient.CreateVirtualHardDisk(ctx, &gowsman.Msvm_VirtualHardDiskSettingData{
+		Path:              vhdPath,
+		VirtualDiskFormat: gowsman.VHDFormatVHDX,
+		VirtualDiskType:   gowsman.VHDTypeDynamic,
+		MaxInternalSize:   1 << 30, // 1 GiB
+	}); err != nil {
+		t.Fatalf("CreateVirtualHardDisk: %v", err)
+	}
+	t.Logf("VHD 作成 (残留・手動削除要): %s", vhdPath)
+
+	// 3. provider の disk 配線で SCSI にアタッチ (表示名指定)。
+	//    シェル VM には SCSI Controller が無いので ensureScsiController が追加してから AttachVHD。
+	//    未対応オプションのガードを通すため既定値 (DiskNumber=MaxUint32 / Primordial / ゼロ GUID) を明示。
+	desired := []api.VmHardDiskDrive{{
+		ControllerType:          api.ControllerType_Scsi,
+		ControllerNumber:        0,
+		ControllerLocation:      0,
+		Path:                    vhdPath,
+		DiskNumber:              4294967295,
+		ResourcePoolName:        "Primordial",
+		QosPolicyId:             "00000000-0000-0000-0000-000000000000",
+		OverrideCacheAttributes: api.CacheAttributes_Default,
+	}}
+	if err := cc.CreateOrUpdateVmHardDiskDrives(ctx, vmName, desired); err != nil {
+		t.Fatalf("CreateOrUpdateVmHardDiskDrives: %v", err)
+	}
+
+	// 4. 逆引き Get で SCSI に VHD が付いたことを検証。
+	got, err := cc.GetVmHardDiskDrives(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmHardDiskDrives: %v", err)
+	}
+	t.Logf("attach 後: disks=%d", len(got))
+	if len(got) != 1 {
+		t.Fatalf("SCSI ディスク 1 本のはず, got %d", len(got))
+	}
+	if got[0].ControllerType != api.ControllerType_Scsi {
+		t.Errorf("ControllerType: got %v, want Scsi", got[0].ControllerType)
+	}
+	if got[0].Path != vhdPath {
+		t.Errorf("Path: got %q, want %q", got[0].Path, vhdPath)
+	}
+	// detach (DeleteVmHardDiskDrive) は go-wsman #97 (Drive 削除が実機 0x80041001) 解消後に検証する。
+	// VM の後始末は t.Cleanup の DeleteVm が担う (VM ごと消せば disk も消える)。
+}

--- a/internal/provider/talos_scsi_boot_integration_test.go
+++ b/internal/provider/talos_scsi_boot_integration_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// #63 「Gen2 SCSI boot 土台」の最終受け入れテスト。go-wsman で配線した SCSI 接続の
+// DVD (Talos metal ISO) から、Gen2 VM が実際にブートすることを実機で確認する。
+//
+// 分担:
+//   - go-wsman (#63 で作った経路 = テスト対象): Gen2 VM 作成 / AddScsiController /
+//     AttachDVD(SCSI) / StartVM / TurnOffVM。
+//   - PowerShell (歴戦の Set-VMFirmware = 検証セットアップ): SecureBoot Off と
+//     FirstBootDevice=DVD の指定、および Heartbeat 統合サービスによるブート検出。
+//     boot order / firmware は #63 のスコープ外 (provider vm_firmware の領分) であり、
+//     WMI の BootSourceOrder を手組みすると golden 偽陽性を招くため OSS 相当の PS に委ねる。
+//
+// 「ブートした」判定は Hyper-V Heartbeat 統合サービスが Ok になること。Heartbeat は
+// VMBus 越しでゲストカーネル + hv_utils が起動して初めて Ok になるため、SCSI 上の ISO から
+// カーネルがロードされた証左になる (firmware 停止のままなら No Contact のまま)。
+// NIC は付けない (Talos は maintenance mode で待機。Heartbeat は VMBus なので NIC 不要)。
+// 稼働中の実クラスタ VM には一切触れない。VHD は作らないので残留物は無し。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	HYPERV_TEST_ALLOW_MUTATION=1 \
+//	go test -tags integration ./internal/provider/ -run TestRealHostTalosScsiBootWsman -v -timeout 400s
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	gowsman "github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostTalosScsiBootWsman(t *testing.T) {
+	if os.Getenv("HYPERV_TEST_ALLOW_MUTATION") == "" {
+		t.Skip("HYPERV_TEST_ALLOW_MUTATION 未設定（VM 作成・起動を伴う破壊的テスト）")
+	}
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	_, runPS := newRealHostHelper(t, c) // firmware 設定と Heartbeat 読み取り用
+	ctx := context.Background()
+
+	const vmName = "tf-wsman-talos-scsi-boot-test"
+	isoPath := os.Getenv("HYPERV_TEST_TALOS_ISO")
+	if isoPath == "" {
+		isoPath = `H:\ISO\metal-amd64.iso` // homelab の talos_iso_path と一致
+	}
+
+	// ISO が実機に無ければスキップ (テスト対象外の前提条件)。
+	if out := strings.TrimSpace(runPS(fmt.Sprintf(`if (Test-Path -LiteralPath '%s') {'yes'} else {'no'}`, isoPath))); out != "yes" {
+		t.Skipf("Talos ISO %q が実機に存在しない (out=%q)", isoPath, out)
+	}
+
+	// 前回残骸を消し、テスト後は確実に停止 → 削除する。
+	_, _ = wsmanClient.TurnOffVM(ctx, vmName) // 表示名でなく GUID 前提なので不在時は無害に失敗
+	_ = cc.DeleteVm(ctx, vmName)
+	t.Cleanup(func() {
+		_ = runPS(fmt.Sprintf(`Stop-VM -Name '%s' -TurnOff -Force -ErrorAction SilentlyContinue`, vmName))
+		if err := cc.DeleteVm(ctx, vmName); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+
+	// 1. 使い捨て Gen2 VM を作成 (2 GiB。Talos は 512 MiB では起動しない)。
+	const memByt = 2147483648 // 2 GiB
+	if err := cc.CreateVm(ctx, vmName,
+		"", 2, // path(既定), generation=2
+		api.CriticalErrorAction_Pause, 0,
+		api.StartAction_Nothing, 0,
+		api.StopAction_Save,
+		api.CheckpointType_Production,
+		false, false, 0,
+		api.OnOffState_Off, 0,
+		memByt, memByt, memByt,
+		"talos-scsi-boot-test", 2,
+		"", "", true, false,
+	); err != nil {
+		t.Fatalf("CreateVm: %v", err)
+	}
+
+	// 表示名 → GUID (go-wsman の storage/state 操作は GUID を要求する)。
+	cs, err := wsmanClient.FindComputerSystemByElementName(ctx, vmName)
+	if err != nil {
+		t.Fatalf("FindComputerSystemByElementName: %v", err)
+	}
+	guid := cs.Name
+
+	// 2. SCSI Controller を追加 (DefineSystem のシェル VM は Gen2 でも SCSI を持たない #88)。
+	scsi, err := wsmanClient.AddScsiController(ctx, guid)
+	if err != nil {
+		t.Fatalf("AddScsiController: %v", err)
+	}
+	if err := wsmanClient.WaitForJob(ctx, scsi.JobRef); err != nil {
+		t.Fatalf("AddScsiController wait: %v", err)
+	}
+
+	// 3. Talos ISO を SCSI の DVD としてマウント (#63 のテスト対象経路)。
+	if _, err := wsmanClient.AttachDVD(ctx, guid, gowsman.AttachDVDOptions{
+		ControllerType:     gowsman.ControllerTypeSCSI,
+		ControllerNumber:   0,
+		ControllerLocation: 0,
+		Path:               isoPath,
+	}); err != nil {
+		t.Fatalf("AttachDVD: %v", err)
+	}
+
+	// 4. firmware: SecureBoot Off + 最初のブートデバイスを DVD に (VM 停止中に設定)。
+	//    Talos は Microsoft UEFI テンプレートでは検証に失敗するため SecureBoot Off が必須。
+	if out := runPS(fmt.Sprintf(
+		`Set-VMFirmware -VMName '%s' -EnableSecureBoot Off; `+
+			`$d = Get-VMDvdDrive -VMName '%s'; `+
+			`Set-VMFirmware -VMName '%s' -FirstBootDevice $d; `+
+			`(Get-VMFirmware -VMName '%s').BootOrder[0].Device.GetType().Name`,
+		vmName, vmName, vmName, vmName)); !strings.Contains(out, "DvdDrive") {
+		t.Fatalf("Set-VMFirmware で FirstBootDevice=DVD にできていない: %q", out)
+	}
+
+	// 5. 起動 (go-wsman StartVM = RequestStateChange(Enabled))。
+	jobRef, err := wsmanClient.StartVM(ctx, guid)
+	if err != nil {
+		t.Fatalf("StartVM: %v", err)
+	}
+	if jobRef != "" {
+		if err := wsmanClient.WaitForJob(ctx, jobRef); err != nil {
+			t.Fatalf("StartVM wait: %v", err)
+		}
+	}
+	t.Logf("VM 起動要求完了。Heartbeat を待機する…")
+
+	// 6. Heartbeat が Ok になるまでポーリング (ゲストカーネル + hv_utils 起動 = SCSI ISO から boot 成功)。
+	const bootTimeout = 240 * time.Second
+	heartbeatCmd := fmt.Sprintf(`(Get-VMIntegrationService -VMName '%s' -Name Heartbeat).PrimaryStatusDescription`, vmName)
+	stateCmd := fmt.Sprintf(`(Get-VM -Name '%s').State`, vmName)
+	deadline := time.Now().Add(bootTimeout)
+	var lastHB, lastState string
+	booted := false
+	for time.Now().Before(deadline) {
+		lastHB = strings.TrimSpace(runPS(heartbeatCmd))
+		lastState = strings.TrimSpace(runPS(stateCmd))
+		t.Logf("[boot 待機] state=%s heartbeat=%q", lastState, lastHB)
+		if strings.EqualFold(lastHB, "OK") {
+			booted = true
+			break
+		}
+		time.Sleep(10 * time.Second)
+	}
+	if !booted {
+		t.Fatalf("Talos が SCSI ISO からブートしなかった (timeout %s): state=%s heartbeat=%q", bootTimeout, lastState, lastHB)
+	}
+
+	uptime := strings.TrimSpace(runPS(fmt.Sprintf(`(Get-VM -Name '%s').Uptime.ToString()`, vmName)))
+	t.Logf("✅ Talos が SCSI 接続の ISO からブート (Heartbeat=OK, uptime=%s)。#63 SCSI boot 土台の実機実証。", uptime)
+
+	// 7. 停止 (go-wsman TurnOffVM)。後始末は t.Cleanup が DeleteVm を担う。
+	if _, err := wsmanClient.TurnOffVM(ctx, guid); err != nil {
+		t.Logf("TurnOffVM: %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

#63 の B side。`HYPERV_USE_WSMAN=1` 時に hard_disk_drive / network_adapter の CRUD を PowerShell 非経由 (go-wsman) にする。Gen2 VM の SCSI ブートディスク + スイッチ接続 NIC で Talos worker 相当を組める土台。

A side (go-wsman SCSI, #86) と逆引きプリミティブ (go-wsman #87) の上に乗る。

> **Draft 理由**: go-wsman #87 (ListDiskDrives / ListEthernetPortAllocations) のマージ待ち。現在 go.mod は #87 のブランチコミットに暫定 pin。**#87 マージ後に `@main` へ再 bump** して Ready にする。

## 変更内容

### hard_disk_drive (api/hyperv-wsman/vm_hard_disk_drive.go)
- Create → `AttachVHD` (IDE/SCSI 分岐、位置指定 0-1/0-63)
- Get → `ListAttachedStorage` + `ListDiskDrives` + `ListIDE/SCSIControllers` の 3 段逆引き (storage→drive→controller)
- Delete → 逆引きで Drive InstanceID 解決 → `DetachStorage`
- Update → detach+attach (go-wsman に in-place 更新なし)
- CreateOrUpdate → 集合差分で収束 (冪等)

### network_adapter (api/hyperv-wsman/vm_network_adapter.go)
- Create → `AddNetworkAdapter` (NIC + スイッチ接続 + MAC)
- Get → `ListNetworkAdapters` + `ListEthernetPortAllocations` + `ListVirtualEthernetSwitches` の逆引き (port→allocation→switch 表示名)
- Delete → 逆引きで Port InstanceID 解決 → `RemoveNetworkAdapter`
- Update → detach+attach / CreateOrUpdate → 集合差分
- `WaitForVmNetworkAdaptersIps` は未定義 (ゲスト IP 取得は KVP 依存のため PowerShell フォールバック)

## 設計判断

- **未対応オプションは silent drop せず明示エラー** (rules 準拠)。disk: QoS/passthrough/カスタムプール/キャッシュ属性/永続予約。nic: QoS/IOV/spoofing/guard/VLAN/帯域/チーミング/PacketDirect 等。VHD パス + IDE/SCSI 位置、NIC + スイッチ + MAC のみ本経路でサポート、残りは v2.1
- **Get 結果は未対応フィールドをスキーマ既定値で埋めて** terraform の差分を防ぐ
- go-wsman は attach/detach しか持たないため CreateOrUpdate は集合差分で収束

## 検証

- `go test ./api/... -count=1`: PASS
- 純関数を table-driven test (型変換 / 未対応判定 / 逆引き結合 / switch 名解決 / reconcile 計画 / interface 実装の reflect チェック)
- `go build ./...` + `go vet ./api/...`: OK
- **実機 acc test 完了** (homelab 10.0.0.100): attach/detach ライフサイクル (disks=1→0) + Gen2 VM の Talos SCSI ISO ブート (Heartbeat=OK) を確認

## 残タスク (このPR外 or 後続)
- [ ] go-wsman #87 マージ → go.mod を `@main` へ再 bump
- [ ] 実機 acc test (Gen2 SCSI boot + NIC)
- [ ] #63 クローズ判定