### PR TITLE
feat: dvd_drive を go-wsman 経由に配線 (#64)

### DIFF
--- a/api/hyperv-wsman/vm_dvd_drive.go
+++ b/api/hyperv-wsman/vm_dvd_drive.go
@@ -1,0 +1,300 @@
+package hyperv_wsman
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// dvd_drive スキーマの既定リソースプール。既定以外が来たら go-wsman 未対応として拒否する。
+const dvdDefaultResourcePool = "Primordial"
+
+// dvdDriveRef は 1 本の DVD (ISO マウント) と、その Detach に必要な InstanceID を束ねる。
+//
+// Detach は「Storage (SASD) 削除 → Drive (RASD) 削除」の 2 段が必須なため、Drive だけでなく
+// Storage の InstanceID も保持する (子 SASD を残したまま Drive を消すと VMMS が拒否する #97)。
+type dvdDriveRef struct {
+	dvd               api.VmDvdDrive
+	driveInstanceID   string // Msvm_ResourceAllocationSettingData (DVD Drive) の InstanceID
+	storageInstanceID string // Msvm_StorageAllocationSettingData (ISO) の InstanceID
+}
+
+// unsupportedDvdOptions は go-wsman 経路が未対応の DVD オプションを拒否する (silent drop 回避)。
+// 現状は既定リソースプール + ISO パス指定のみサポートする。
+func unsupportedDvdOptions(resourcePoolName string) error {
+	if resourcePoolName != "" && resourcePoolName != dvdDefaultResourcePool {
+		return fmt.Errorf(
+			"hyperv-wsman: dvd_drive の resource_pool_name は go-wsman 経路 (HYPERV_USE_WSMAN) では未対応です。"+
+				"PowerShell 経路を使うか、既定値 %q にしてください", dvdDefaultResourcePool)
+	}
+	return nil
+}
+
+// vmIsGen2 は VM が Generation 2 (UEFI) かを VirtualSystemSubType で判定する。
+// Gen2 は DVD/ディスクを SCSI に、Gen1 は IDE に接続するため、アタッチ先 Controller 種別の決定に使う。
+func (c *ClientConfig) vmIsGen2(ctx context.Context, vmGUID string) (bool, error) {
+	sd, err := c.WsmanClient.GetSystemSettingData(ctx, vmGUID)
+	if err != nil {
+		return false, fmt.Errorf("hyperv-wsman: 世代判定 %q: %w", vmGUID, err)
+	}
+	return sd.VirtualSystemSubType == hyperv.VirtualSystemSubTypeGen2, nil
+}
+
+// CreateVmDvdDrive は go-wsman 経由で ISO を DVD ドライブとしてマウントする。
+//
+// VmDvdDrive は controller 種別を持たないため、VM の世代からアタッチ先を決める
+// (Gen2→SCSI / Gen1→IDE)。PowerShell の Add-VMDvdDrive と同じ自動選択。
+func (c *ClientConfig) CreateVmDvdDrive(
+	ctx context.Context,
+	vmName string,
+	controllerNumber int,
+	controllerLocation int,
+	path string,
+	resourcePoolName string,
+) error {
+	if err := unsupportedDvdOptions(resourcePoolName); err != nil {
+		return err
+	}
+	// 空メディア (ISO 未指定の DVD ドライブのみ追加) は go-wsman AttachDVD が storage を要求するため
+	// 現状未対応。ISO マウントに絞る (silent drop 回避のため明示的に拒否)。空メディア対応は v2.1。
+	if path == "" {
+		return fmt.Errorf("hyperv-wsman: CreateVmDvdDrive %q: ISO パス空 (メディアなし DVD) は go-wsman 経路では未対応", vmName)
+	}
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmDvdDrive %q: %w", vmName, err)
+	}
+	gen2, err := c.vmIsGen2(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmDvdDrive %q: %w", vmName, err)
+	}
+	ct := hyperv.ControllerTypeIDE
+	if gen2 {
+		// go-wsman で作った Gen2 VM はシェル状態で SCSI Controller を持たない (#88) ため保証する。
+		ct = hyperv.ControllerTypeSCSI
+		if err := c.ensureScsiController(ctx, guid, int32(controllerNumber)); err != nil {
+			return err
+		}
+	}
+	// AttachDVD は内部で Drive/Storage の非同期 Job 完了まで待つ (go-wsman 側)。
+	if _, err := c.WsmanClient.AttachDVD(ctx, guid, hyperv.AttachDVDOptions{
+		ControllerType:     ct,
+		ControllerNumber:   controllerNumber,
+		ControllerLocation: controllerLocation,
+		Path:               path,
+	}); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmDvdDrive %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// GetVmDvdDrives は VM にマウントされた ISO 一覧を返す (go-wsman 逆引き)。
+func (c *ClientConfig) GetVmDvdDrives(ctx context.Context, vmName string) ([]api.VmDvdDrive, error) {
+	refs, err := c.getDvdDriveRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]api.VmDvdDrive, 0, len(refs))
+	for _, r := range refs {
+		result = append(result, r.dvd)
+	}
+	return result, nil
+}
+
+// DeleteVmDvdDrive は index 番目の DVD を go-wsman 経由で Detach する (Storage→Drive 2 段削除)。
+func (c *ClientConfig) DeleteVmDvdDrive(ctx context.Context, vmName string, index int) error {
+	refs, err := c.getDvdDriveRefs(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	if index < 0 || index >= len(refs) {
+		return fmt.Errorf("hyperv-wsman: DeleteVmDvdDrive %q: index %d out of range (VM has %d DVDs)", vmName, index, len(refs))
+	}
+	if _, err := c.WsmanClient.DetachStorage(ctx, refs[index].driveInstanceID, refs[index].storageInstanceID); err != nil {
+		return fmt.Errorf("hyperv-wsman: DeleteVmDvdDrive %q: %w", vmName, err)
+	}
+	return nil
+}
+
+// UpdateVmDvdDrive は index 番目の DVD を所望の状態に置き換える (Detach してから再 Attach)。
+func (c *ClientConfig) UpdateVmDvdDrive(
+	ctx context.Context,
+	vmName string,
+	index int,
+	controllerNumber int,
+	controllerLocation int,
+	path string,
+	resourcePoolName string,
+) error {
+	if err := unsupportedDvdOptions(resourcePoolName); err != nil {
+		return err
+	}
+	if err := c.DeleteVmDvdDrive(ctx, vmName, index); err != nil {
+		return err
+	}
+	return c.CreateVmDvdDrive(ctx, vmName, controllerNumber, controllerLocation, path, resourcePoolName)
+}
+
+// CreateOrUpdateVmDvdDrives は所望の DVD 集合に収束させる (go-wsman)。
+//
+// go-wsman は attach/detach しか持たないため、集合差分で収束する: 現状にあって所望に無い ISO を
+// Detach、所望にあって現状に無い ISO を Attach する。冪等。
+func (c *ClientConfig) CreateOrUpdateVmDvdDrives(ctx context.Context, vmName string, dvdDrives []api.VmDvdDrive) error {
+	for _, d := range dvdDrives {
+		if err := unsupportedDvdOptions(d.ResourcePoolName); err != nil {
+			return err
+		}
+	}
+	current, err := c.getDvdDriveRefs(ctx, vmName)
+	if err != nil {
+		return err
+	}
+	toDetach, toAttach := planDvdDriveReconcile(current, dvdDrives)
+	for _, r := range toDetach {
+		if _, err := c.WsmanClient.DetachStorage(ctx, r.driveInstanceID, r.storageInstanceID); err != nil {
+			return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmDvdDrives %q: detach: %w", vmName, err)
+		}
+	}
+	for _, d := range toAttach {
+		if err := c.CreateVmDvdDrive(ctx, vmName, d.ControllerNumber, d.ControllerLocation, d.Path, d.ResourcePoolName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getDvdDriveRefs は VM の DVD 一覧を go-wsman の逆引きで組み立てる (順序安定)。
+//
+// storage(ISO) → drive(Controller 内位置) → controller(IDE/SCSI 種別・番号) の 3 段結合で
+// provider の VmDvdDrive を復元する。Detach 用に Drive/Storage の InstanceID も保持する。
+func (c *ClientConfig) getDvdDriveRefs(ctx context.Context, vmName string) ([]dvdDriveRef, error) {
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: get dvd drives %q: %w", vmName, err)
+	}
+	storages, err := c.WsmanClient.ListAttachedStorage(ctx, guid)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list attached storage %q: %w", vmName, err)
+	}
+	dvdDrives, err := c.WsmanClient.ListDvdDrives(ctx, guid)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list dvd drives %q: %w", vmName, err)
+	}
+	ideCtrls, err := c.WsmanClient.ListIDEControllers(ctx, guid)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list IDE controllers %q: %w", vmName, err)
+	}
+	scsiCtrls, err := c.WsmanClient.ListSCSIControllers(ctx, guid)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: list SCSI controllers %q: %w", vmName, err)
+	}
+	return mapDvdDriveRefs(vmName, storages, dvdDrives, ideCtrls, scsiCtrls), nil
+}
+
+// mapDvdDriveRefs は go-wsman の storage/drive/controller 一覧を結合して VmDvdDrive を復元する。
+//
+// storage.Parent → dvdDrive.InstanceID、dvdDrive.Parent → controller.InstanceID の 2 段で親を辿る。
+// VmDvdDrive は controller 種別を持たないが、VM は Gen1(IDE のみ)/Gen2(SCSI のみ) で種別が一意に
+// 決まるため、Controller の一覧内 index をそのまま controller 番号として報告できる。
+// ISO (Virtual CD/DVD Disk) のみ対象とし、VHD は除外する。結果は (番号, 位置) で安定ソート。
+func mapDvdDriveRefs(
+	vmName string,
+	storages []*hyperv.Msvm_StorageAllocationSettingData,
+	dvdDrives []*hyperv.Msvm_ResourceAllocationSettingData,
+	ideCtrls []*hyperv.Msvm_ResourceAllocationSettingData,
+	scsiCtrls []*hyperv.Msvm_ResourceAllocationSettingData,
+) []dvdDriveRef {
+	driveByID := make(map[string]*hyperv.Msvm_ResourceAllocationSettingData, len(dvdDrives))
+	for _, d := range dvdDrives {
+		driveByID[d.InstanceID] = d
+	}
+	// controller InstanceID → 番号。WS-Man の列挙順は無保証なので InstanceID でソートしてから
+	// 番号を振る (disk と同じ決定的順序。読み取りごとに番号が入れ替わると誤 detach を招く)。
+	sortByInstanceID(ideCtrls)
+	sortByInstanceID(scsiCtrls)
+	ctrlByID := make(map[string]int)
+	for i, cc := range ideCtrls {
+		ctrlByID[cc.InstanceID] = i
+	}
+	for i, cc := range scsiCtrls {
+		ctrlByID[cc.InstanceID] = i
+	}
+
+	refs := make([]dvdDriveRef, 0, len(storages))
+	for _, s := range storages {
+		if s.ResourceSubType != hyperv.ResourceSubTypeVirtualCDDVDDisk {
+			continue // VHD/その他は対象外
+		}
+		drive := driveByID[matchRefKey(s.Parent, driveByID)]
+		if drive == nil {
+			continue // 親 DVD Drive が特定できない
+		}
+		number, ok := ctrlByID[matchRefKey(drive.Parent, ctrlByID)]
+		if !ok {
+			continue // 親 Controller が特定できない
+		}
+		// パース失敗は握り潰さずスキップ (location=0 に化けると 0 番と衝突し reconcile が誤判断)。
+		location, err := strconv.Atoi(drive.AddressOnParent)
+		if err != nil {
+			continue
+		}
+		refs = append(refs, dvdDriveRef{
+			driveInstanceID:   drive.InstanceID,
+			storageInstanceID: s.InstanceID,
+			dvd: api.VmDvdDrive{
+				VmName:             vmName,
+				ControllerNumber:   number,
+				ControllerLocation: location,
+				Path:               s.HostResource,
+				ResourcePoolName:   dvdDefaultResourcePool,
+			},
+		})
+	}
+	sortDvdDriveRefs(refs)
+	return refs
+}
+
+// sortDvdDriveRefs は (controller 番号, 位置) で安定ソートする。
+func sortDvdDriveRefs(refs []dvdDriveRef) {
+	sort.SliceStable(refs, func(i, j int) bool {
+		if refs[i].dvd.ControllerNumber != refs[j].dvd.ControllerNumber {
+			return refs[i].dvd.ControllerNumber < refs[j].dvd.ControllerNumber
+		}
+		return refs[i].dvd.ControllerLocation < refs[j].dvd.ControllerLocation
+	})
+}
+
+// dvdDriveKey は DVD の同一性キー (controller 番号 / 位置 / ISO パス)。パスは大小無視 (Windows 慣習)。
+func dvdDriveKey(d api.VmDvdDrive) string {
+	return fmt.Sprintf("%d/%d/%s", d.ControllerNumber, d.ControllerLocation, strings.ToLower(d.Path))
+}
+
+// planDvdDriveReconcile は現状 refs を所望 desired に収束させる detach/attach 計画を返す。
+// 現状にあって所望に無いものを Detach (Storage/Drive の 2 段削除に両 InstanceID が要る)、
+// 所望にあって現状に無いものを Attach。純関数なので table-driven test で検証できる。
+func planDvdDriveReconcile(current []dvdDriveRef, desired []api.VmDvdDrive) (toDetach []dvdDriveRef, toAttach []api.VmDvdDrive) {
+	currentKeys := make(map[string]struct{}, len(current))
+	for _, r := range current {
+		currentKeys[dvdDriveKey(r.dvd)] = struct{}{}
+	}
+	desiredKeys := make(map[string]struct{}, len(desired))
+	for _, d := range desired {
+		desiredKeys[dvdDriveKey(d)] = struct{}{}
+	}
+	for _, r := range current {
+		if _, ok := desiredKeys[dvdDriveKey(r.dvd)]; !ok {
+			toDetach = append(toDetach, r)
+		}
+	}
+	for _, d := range desired {
+		if _, ok := currentKeys[dvdDriveKey(d)]; !ok {
+			toAttach = append(toAttach, d)
+		}
+	}
+	return toDetach, toAttach
+}

--- a/api/hyperv-wsman/vm_dvd_drive_test.go
+++ b/api/hyperv-wsman/vm_dvd_drive_test.go
@@ -1,0 +1,146 @@
+package hyperv_wsman
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// TestClientConfig_ImplementsHypervVmDvdDriveClient は ClientConfig が
+// api.HypervVmDvdDriveClient を実装し、全メソッドが本パッケージでシャドウイングされて
+// いることを検証する (未シャドウなら PowerShell 経路にフォールバックしてしまう)。
+func TestClientConfig_ImplementsHypervVmDvdDriveClient(t *testing.T) {
+	var c *ClientConfig
+	var _ api.HypervVmDvdDriveClient = c // コンパイル時チェック
+
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	for _, methodName := range []string{
+		"CreateVmDvdDrive",
+		"GetVmDvdDrives",
+		"UpdateVmDvdDrive",
+		"DeleteVmDvdDrive",
+		"CreateOrUpdateVmDvdDrives",
+	} {
+		if _, ok := cType.MethodByName(methodName); !ok {
+			t.Errorf("メソッド %s が hyperv-wsman で定義されていない (シャドウイングされない)", methodName)
+		}
+	}
+}
+
+// TestMapDvdDriveRefs は ISO(Virtual CD/DVD Disk)のみ復元し、VHD を除外することを検証する。
+func TestMapDvdDriveRefs(t *testing.T) {
+	vm := "11111111-aaaa-bbbb-cccc-000000000001"
+	scsiCtrl := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\SCSI-CTRL-0`}
+
+	dvdDrive := &hyperv.Msvm_ResourceAllocationSettingData{
+		InstanceID: `Microsoft:` + vm + `\DVD-SCSI`, Parent: scsiCtrl.InstanceID, AddressOnParent: "1",
+	}
+	storages := []*hyperv.Msvm_StorageAllocationSettingData{
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualCDDVDDisk, HostResource: `H:\ISO\talos.iso`, Parent: dvdDrive.InstanceID, InstanceID: `Microsoft:` + vm + `\ISO-0`},
+		// VHD は対象外 (除外されること)
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualHardDisk, HostResource: `D:\VMs\boot.vhdx`, Parent: dvdDrive.InstanceID},
+	}
+
+	got := mapDvdDriveRefs(vm, storages,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{dvdDrive},
+		nil,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{scsiCtrl},
+	)
+
+	if len(got) != 1 {
+		t.Fatalf("len: got %d, want 1 (VHD は除外)", len(got))
+	}
+	if got[0].dvd.ControllerNumber != 0 || got[0].dvd.ControllerLocation != 1 {
+		t.Errorf("controller: got num=%d loc=%d, want num=0 loc=1", got[0].dvd.ControllerNumber, got[0].dvd.ControllerLocation)
+	}
+	if got[0].dvd.Path != `H:\ISO\talos.iso` {
+		t.Errorf("Path: got %q", got[0].dvd.Path)
+	}
+	// Detach に必要な両 InstanceID が取れていること (#97 の 2 段削除用)。
+	if got[0].driveInstanceID != dvdDrive.InstanceID {
+		t.Errorf("driveInstanceID: got %q", got[0].driveInstanceID)
+	}
+	if got[0].storageInstanceID != `Microsoft:`+vm+`\ISO-0` {
+		t.Errorf("storageInstanceID: got %q", got[0].storageInstanceID)
+	}
+	if got[0].dvd.ResourcePoolName != dvdDefaultResourcePool {
+		t.Errorf("ResourcePoolName: got %q, want %q", got[0].dvd.ResourcePoolName, dvdDefaultResourcePool)
+	}
+}
+
+// TestMapDvdDriveRefs_Gen1IDE は Gen1 の IDE 上の DVD で controller 番号が IDE index に
+// なることを検証する (homelab controlplane の dvd_drives{controller_number=1} 相当)。
+func TestMapDvdDriveRefs_Gen1IDE(t *testing.T) {
+	vm := "vm1"
+	ide0 := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\IDE-0`}
+	ide1 := &hyperv.Msvm_ResourceAllocationSettingData{InstanceID: `Microsoft:` + vm + `\IDE-1`}
+	dvdOnIde1 := &hyperv.Msvm_ResourceAllocationSettingData{
+		InstanceID: `Microsoft:` + vm + `\DVD-IDE1`, Parent: ide1.InstanceID, AddressOnParent: "0",
+	}
+	storages := []*hyperv.Msvm_StorageAllocationSettingData{
+		{ResourceSubType: hyperv.ResourceSubTypeVirtualCDDVDDisk, HostResource: `H:\ISO\talos.iso`, Parent: dvdOnIde1.InstanceID},
+	}
+	got := mapDvdDriveRefs(vm, storages,
+		[]*hyperv.Msvm_ResourceAllocationSettingData{dvdOnIde1},
+		[]*hyperv.Msvm_ResourceAllocationSettingData{ide0, ide1},
+		nil,
+	)
+	if len(got) != 1 {
+		t.Fatalf("len: got %d, want 1", len(got))
+	}
+	if got[0].dvd.ControllerNumber != 1 {
+		t.Errorf("ControllerNumber: got %d, want 1 (IDE-1)", got[0].dvd.ControllerNumber)
+	}
+}
+
+// TestPlanDvdDriveReconcile は集合差分の detach/attach 計画を検証する。
+func TestPlanDvdDriveReconcile(t *testing.T) {
+	mkRef := func(num, loc int, path string) dvdDriveRef {
+		return dvdDriveRef{
+			driveInstanceID:   path + "-drive",
+			storageInstanceID: path + "-storage",
+			dvd:               api.VmDvdDrive{ControllerNumber: num, ControllerLocation: loc, Path: path},
+		}
+	}
+	mkD := func(num, loc int, path string) api.VmDvdDrive {
+		return api.VmDvdDrive{ControllerNumber: num, ControllerLocation: loc, Path: path}
+	}
+
+	t.Run("変化なし", func(t *testing.T) {
+		cur := []dvdDriveRef{mkRef(0, 1, `H:\ISO\talos.iso`)}
+		des := []api.VmDvdDrive{mkD(0, 1, `H:\ISO\talos.iso`)}
+		detach, attach := planDvdDriveReconcile(cur, des)
+		if len(detach) != 0 || len(attach) != 0 {
+			t.Errorf("変化なしのはず: detach=%v attach=%v", detach, attach)
+		}
+	})
+	t.Run("パス大小違いは同一", func(t *testing.T) {
+		cur := []dvdDriveRef{mkRef(0, 1, `H:\ISO\Talos.iso`)}
+		des := []api.VmDvdDrive{mkD(0, 1, `h:\iso\talos.iso`)}
+		detach, attach := planDvdDriveReconcile(cur, des)
+		if len(detach) != 0 || len(attach) != 0 {
+			t.Errorf("大小違いは同一のはず: detach=%v attach=%v", detach, attach)
+		}
+	})
+	t.Run("ISO差し替え = detach+attach", func(t *testing.T) {
+		cur := []dvdDriveRef{mkRef(0, 1, `H:\ISO\old.iso`)}
+		des := []api.VmDvdDrive{mkD(0, 1, `H:\ISO\new.iso`)}
+		detach, attach := planDvdDriveReconcile(cur, des)
+		if len(detach) != 1 || detach[0].storageInstanceID != `H:\ISO\old.iso-storage` {
+			t.Errorf("detach: got %v", detach)
+		}
+		if len(attach) != 1 || attach[0].Path != `H:\ISO\new.iso` {
+			t.Errorf("attach: got %v", attach)
+		}
+	})
+	t.Run("boot後デタッチ = detachのみ", func(t *testing.T) {
+		// Talos boot 後に ISO を外す (desired 空) → detach 1 本、attach なし。
+		cur := []dvdDriveRef{mkRef(0, 1, `H:\ISO\talos.iso`)}
+		detach, attach := planDvdDriveReconcile(cur, nil)
+		if len(detach) != 1 || len(attach) != 0 {
+			t.Errorf("boot後デタッチは detach のみ: detach=%v attach=%v", detach, attach)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260704091054-6f80bb555148
+	github.com/r4sd/go-wsman v0.0.0-20260706144934-2bbaea5be96b
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260704091054-6f80bb555148 h1:GgUE1HN/yRmPCv3H76lXeGg+motIO2F32gUI2/zry9U=
-github.com/r4sd/go-wsman v0.0.0-20260704091054-6f80bb555148/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260706144934-2bbaea5be96b h1:PeOStoleuCHE95l7MjzBgKS4Vun23a6GFvMTWIhz3QY=
+github.com/r4sd/go-wsman v0.0.0-20260706144934-2bbaea5be96b/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/dvd_write_integration_test.go
+++ b/internal/provider/dvd_write_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の DVD (ISO マウント) 配線 (#64) の実機統合テスト。
+//
+// 使い捨て Gen2 VM を作り、provider の CreateOrUpdateVmDvdDrives で Talos ISO を SCSI に
+// マウント、GetVmDvdDrives の逆引きで検証、desired を空にして「boot 後デタッチ」相当の
+// detach まで一周する (Storage→Drive の 2 段削除 #97 経由)。稼働中 VM は触らない。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	HYPERV_TEST_ALLOW_MUTATION=1 \
+//	go test -tags integration ./internal/provider/ -run TestRealHostDvdWriteWsman -v
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostDvdWriteWsman(t *testing.T) {
+	if os.Getenv("HYPERV_TEST_ALLOW_MUTATION") == "" {
+		t.Skip("HYPERV_TEST_ALLOW_MUTATION 未設定（VM 作成を伴う破壊的テスト）")
+	}
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	_, runPS := newRealHostHelper(t, c) // ISO 存在確認用
+	ctx := context.Background()
+
+	const vmName = "tf-wsman-dvd-write-test"
+	isoPath := os.Getenv("HYPERV_TEST_TALOS_ISO")
+	if isoPath == "" {
+		isoPath = `H:\ISO\metal-amd64.iso`
+	}
+	if out := strings.TrimSpace(runPS("if (Test-Path -LiteralPath '" + isoPath + "') {'yes'} else {'no'}")); out != "yes" {
+		t.Skipf("ISO %q が実機に無い (out=%q)", isoPath, out)
+	}
+
+	_ = cc.DeleteVm(ctx, vmName)
+	t.Cleanup(func() {
+		if err := cc.DeleteVm(ctx, vmName); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+
+	// 1. 使い捨て Gen2 VM。
+	const memByt = 536870912 // 512 MiB (起動しないので最小で可)
+	if err := cc.CreateVm(ctx, vmName,
+		"", 2,
+		api.CriticalErrorAction_Pause, 0,
+		api.StartAction_Nothing, 0,
+		api.StopAction_Save,
+		api.CheckpointType_Production,
+		false, false, 0,
+		api.OnOffState_Off, 0,
+		memByt, memByt, memByt,
+		"dvd-write-test", 1,
+		"", "", true, false,
+	); err != nil {
+		t.Fatalf("CreateVm: %v", err)
+	}
+
+	// 2. provider の dvd 配線で Talos ISO を SCSI にマウント (Gen2 → 自動で SCSI)。
+	desired := []api.VmDvdDrive{{
+		VmName:             vmName,
+		ControllerNumber:   0,
+		ControllerLocation: 0,
+		Path:               isoPath,
+		ResourcePoolName:   "Primordial",
+	}}
+	if err := cc.CreateOrUpdateVmDvdDrives(ctx, vmName, desired); err != nil {
+		t.Fatalf("CreateOrUpdateVmDvdDrives: %v", err)
+	}
+
+	// 3. 逆引き Get で ISO が付いたことを検証。
+	got, err := cc.GetVmDvdDrives(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmDvdDrives: %v", err)
+	}
+	t.Logf("mount 後: dvds=%d", len(got))
+	if len(got) != 1 {
+		t.Fatalf("DVD 1 本のはず, got %d", len(got))
+	}
+	if !strings.EqualFold(got[0].Path, isoPath) {
+		t.Errorf("Path: got %q, want %q", got[0].Path, isoPath)
+	}
+
+	// 4. 冪等性: 同じ desired を再適用しても変化しない (mount→mount で 1 本のまま)。
+	if err := cc.CreateOrUpdateVmDvdDrives(ctx, vmName, desired); err != nil {
+		t.Fatalf("CreateOrUpdateVmDvdDrives (再適用): %v", err)
+	}
+	if again, err := cc.GetVmDvdDrives(ctx, vmName); err != nil || len(again) != 1 {
+		t.Fatalf("冪等でない: err=%v len=%d (want 1)", err, len(again))
+	}
+
+	// 5. boot 後デタッチ相当: desired を空にして detach (Storage→Drive 2 段削除 #97)。
+	if err := cc.CreateOrUpdateVmDvdDrives(ctx, vmName, nil); err != nil {
+		t.Fatalf("CreateOrUpdateVmDvdDrives (detach): %v", err)
+	}
+	after, err := cc.GetVmDvdDrives(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmDvdDrives (detach 後): %v", err)
+	}
+	t.Logf("detach 後: dvds=%d", len(after))
+	if len(after) != 0 {
+		t.Fatalf("detach 後は 0 本のはず, got %d", len(after))
+	}
+}


### PR DESCRIPTION
## 変更内容

hard_disk_drive (#63/#65) と同じく `dvd_drive` の CRUD を go-wsman (WS-Man/CIM) 経由にする (#64)。Talos の ISO マウント → boot 後デタッチ運用に対応。

## 設計

- `vm_dvd_drive.go`: Create/Get/Update/Delete/CreateOrUpdate を wsman `ClientConfig` でシャドウイング。集合差分で収束(冪等)。
- `VmDvdDrive` は controller 種別を持たないため、VM 世代 (`VirtualSystemSubType`) でアタッチ先を自動選択(Gen2→SCSI / Gen1→IDE)。PowerShell の `Add-VMDvdDrive` と同じ。
- Detach は Storage(SASD)→Drive(RASD) の 2 段削除(#97)。両 InstanceID を `dvdDriveRef` で保持。
- go-wsman は `ListDvdDrives` 込みの @main に更新。
- 空メディア(ISO 未指定)DVD は未対応として明示拒否(silent drop 回避、v2.1)。

## 検証結果

- unit: mapper(ISO のみ復元・VHD 除外・Gen1 IDE 番号)、reconcile(冪等・大小無視・差し替え・boot 後デタッチ)、interface 実装。
- 実機 acc test (homelab 10.0.0.100 `TestRealHostDvdWriteWsman`): Gen2 VM に Talos ISO を SCSI マウント→Get 逆引き 1 本→冪等再適用→detach で 0 本を確認。
- `go test ./api/hyperv-wsman/...` 全 GREEN。