### PR TITLE
fix: dvd_drive の未対応オプション検証を破壊操作の前に前倒し (#66 review)

### DIFF
--- a/api/hyperv-wsman/vm_dvd_drive.go
+++ b/api/hyperv-wsman/vm_dvd_drive.go
@@ -24,13 +24,22 @@ type dvdDriveRef struct {
 	storageInstanceID string // Msvm_StorageAllocationSettingData (ISO) の InstanceID
 }
 
-// unsupportedDvdOptions は go-wsman 経路が未対応の DVD オプションを拒否する (silent drop 回避)。
+// validateDvdOptions は go-wsman 経路が未対応の DVD オプションを拒否する (silent drop 回避)。
 // 現状は既定リソースプール + ISO パス指定のみサポートする。
-func unsupportedDvdOptions(resourcePoolName string) error {
+//
+// path/pool の両方をここで検証するのが重要: Update / CreateOrUpdate は破壊操作 (detach) を
+// 実行してから attach するため、未対応値の検出が attach まで遅れると「detach 済み・attach 拒否」
+// の部分適用で state が乖離する。呼び出し側は必ず破壊操作の前に本関数で全件検証すること。
+func validateDvdOptions(path, resourcePoolName string) error {
 	if resourcePoolName != "" && resourcePoolName != dvdDefaultResourcePool {
 		return fmt.Errorf(
 			"hyperv-wsman: dvd_drive の resource_pool_name は go-wsman 経路 (HYPERV_USE_WSMAN) では未対応です。"+
 				"PowerShell 経路を使うか、既定値 %q にしてください", dvdDefaultResourcePool)
+	}
+	// 空メディア (ISO 未指定の DVD ドライブのみ追加) は go-wsman AttachDVD が storage を要求するため
+	// 現状未対応。ISO マウントに絞る。空メディア対応は v2.1 (#67)。
+	if path == "" {
+		return fmt.Errorf("hyperv-wsman: dvd_drive の ISO パス空 (メディアなし DVD) は go-wsman 経路では未対応です。空メディア対応は v2.1 (#67)")
 	}
 	return nil
 }
@@ -57,13 +66,8 @@ func (c *ClientConfig) CreateVmDvdDrive(
 	path string,
 	resourcePoolName string,
 ) error {
-	if err := unsupportedDvdOptions(resourcePoolName); err != nil {
-		return err
-	}
-	// 空メディア (ISO 未指定の DVD ドライブのみ追加) は go-wsman AttachDVD が storage を要求するため
-	// 現状未対応。ISO マウントに絞る (silent drop 回避のため明示的に拒否)。空メディア対応は v2.1。
-	if path == "" {
-		return fmt.Errorf("hyperv-wsman: CreateVmDvdDrive %q: ISO パス空 (メディアなし DVD) は go-wsman 経路では未対応", vmName)
+	if err := validateDvdOptions(path, resourcePoolName); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateVmDvdDrive %q: %w", vmName, err)
 	}
 	guid, err := c.resolveVMGUID(ctx, vmName)
 	if err != nil {
@@ -131,8 +135,10 @@ func (c *ClientConfig) UpdateVmDvdDrive(
 	path string,
 	resourcePoolName string,
 ) error {
-	if err := unsupportedDvdOptions(resourcePoolName); err != nil {
-		return err
+	// 破壊操作 (Delete) の前に検証する。attach 段階まで遅らせると Delete 成功後に Create が
+	// 拒否して部分適用になる (ISO が外れたまま失敗)。
+	if err := validateDvdOptions(path, resourcePoolName); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVmDvdDrive %q: %w", vmName, err)
 	}
 	if err := c.DeleteVmDvdDrive(ctx, vmName, index); err != nil {
 		return err
@@ -145,9 +151,11 @@ func (c *ClientConfig) UpdateVmDvdDrive(
 // go-wsman は attach/detach しか持たないため、集合差分で収束する: 現状にあって所望に無い ISO を
 // Detach、所望にあって現状に無い ISO を Attach する。冪等。
 func (c *ClientConfig) CreateOrUpdateVmDvdDrives(ctx context.Context, vmName string, dvdDrives []api.VmDvdDrive) error {
+	// 未対応オプションは detach/attach を始める前に全件検証する。attach 段階で初めて弾くと、
+	// 先行する detach だけが実機に適用されて部分適用・state 乖離になる (レビュー #66)。
 	for _, d := range dvdDrives {
-		if err := unsupportedDvdOptions(d.ResourcePoolName); err != nil {
-			return err
+		if err := validateDvdOptions(d.Path, d.ResourcePoolName); err != nil {
+			return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmDvdDrives %q: %w", vmName, err)
 		}
 	}
 	current, err := c.getDvdDriveRefs(ctx, vmName)

--- a/api/hyperv-wsman/vm_dvd_drive_test.go
+++ b/api/hyperv-wsman/vm_dvd_drive_test.go
@@ -29,6 +29,31 @@ func TestClientConfig_ImplementsHypervVmDvdDriveClient(t *testing.T) {
 	}
 }
 
+// TestValidateDvdOptions は未対応オプション(空 ISO パス・非既定リソースプール)を破壊操作の
+// 前に弾くことを検証する。attach まで遅れると部分適用で state 乖離する (レビュー #66)。
+func TestValidateDvdOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		pool    string
+		wantErr bool
+	}{
+		{"正常: ISO+既定プール", `H:\ISO\talos.iso`, "Primordial", false},
+		{"正常: プール空文字も既定扱い", `H:\ISO\talos.iso`, "", false},
+		{"拒否: 空メディア(パス空)", "", "Primordial", true},
+		{"拒否: 非既定プール", `H:\ISO\talos.iso`, "CustomPool", true},
+		{"拒否: パス空とプール両方不正でも弾く", "", "CustomPool", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDvdOptions(tt.path, tt.pool)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateDvdOptions(%q,%q): err=%v, wantErr=%v", tt.path, tt.pool, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestMapDvdDriveRefs は ISO(Virtual CD/DVD Disk)のみ復元し、VHD を除外することを検証する。
 func TestMapDvdDriveRefs(t *testing.T) {
 	vm := "11111111-aaaa-bbbb-cccc-000000000001"


### PR DESCRIPTION
## 変更内容

PR #66 の Fable レビューで見つかった**確定バグ**を修正する。

`Update` / `CreateOrUpdateVmDvdDrives` は detach(破壊)→attach の順で集合収束するが、空 ISO パス(go-wsman 未対応)の検出が attach 段階まで遅れていたため、既存 ISO を **detach 成功後に attach が拒否 → 部分適用・state 乖離**を起こしていた。

## 修正

- `unsupportedDvdOptions(pool)` を `validateDvdOptions(path, pool)` に一般化し、`path==""` も含めて**破壊操作の前に全件検証**する(Create/Update/CreateOrUpdate の全経路)。
- validation の unit test を追加(正常 / 空パス / 非既定プール)。development.md「バリデーション=テスト必須」に準拠。

## レビュー他項目の扱い(頻度×直し切れるかで線引き)

- **#3 稼働中 Gen2 SCSI detach / #4 Gen1 IDE 存在**: 実機で verify → **どちらも問題なし**(Gen1 シェル VM は IDE 2 本を既定保持 / 稼働中 Gen2 VM から SCSI ISO detach 成功)。よくある運用パターンは動く。
- **空メディア DVD の構造的サポート**(読み取り RASD 起点化含む): #67 で v2.1。
- **重複整理 / shadowing テスト実効化 / GUID 重複解決**: #68 で v2.1。

## 検証結果
- unit 全 GREEN、実機 acc test (`TestRealHostDvdWriteWsman`) 回帰なし。