### PR TITLE
fix: strict Read の PS フォールスルーを解消 (#72, #76)

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -36,6 +36,11 @@ func (c *ClientConfig) VmExists(ctx context.Context, name string) (api.VmExists,
 func (c *ClientConfig) GetVm(ctx context.Context, name string) (api.Vm, error) {
 	cs, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name)
 	if err != nil {
+		// go-wsman の不在エラーは api 境界で api.ErrVMNotFound へ変換し、provider が
+		// go-wsman に依存せず不在を判定できるようにする (VmExists と同じ方針)。
+		if errors.Is(err, hyperv.ErrVMNotFound) {
+			return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, api.ErrVMNotFound)
+		}
 		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
 	}
 	sd, err := c.WsmanClient.GetSystemSettingData(ctx, cs.Name)

--- a/api/hyperv-wsman/vm_network_adapter.go
+++ b/api/hyperv-wsman/vm_network_adapter.go
@@ -281,9 +281,27 @@ func (c *ClientConfig) CreateOrUpdateVmNetworkAdapters(ctx context.Context, vmNa
 	return nil
 }
 
-// WaitForVmNetworkAdaptersIps は go-wsman 経路では未実装のため PowerShell 実装にフォールバックする。
-// (ゲスト IP 取得は KVP/統合サービス依存。埋め込んだ hyperv_winrm.ClientConfig が処理する。)
-// —— 明示定義しないことで promotion による PowerShell フォールバックを効かせる。
+// WaitForVmNetworkAdaptersIps は全 NIC が wait_for_ips=false のとき PowerShell 呼び出しを省く。
+//
+// go-wsman はゲスト IP 取得 (KVP/Msvm_GuestNetworkAdapterConfiguration) を持たないため、実際に
+// IP 待ちが要る場合のみ埋め込んだ winrm 実装 (PS) に委譲する。1 つでも wait_for_ips=true があれば
+// 従来どおり PS で待機し、全て false なら PS を出さず即 return して strict mode (PS 0 件) を満たす。
+// winrm 実装はリストが非空なら中身が false でも PS を流すため、homelab (wait_for_ips=false×2 の
+// 非空リスト) を「空リスト時スキップ」ではカバーできない。「全 false ならスキップ」が正。
+func (c *ClientConfig) WaitForVmNetworkAdaptersIps(
+	ctx context.Context,
+	vmName string,
+	timeout uint32,
+	pollPeriod uint32,
+	vmNetworkAdaptersWaitForIps []api.VmNetworkAdapterWaitForIp,
+) error {
+	for _, w := range vmNetworkAdaptersWaitForIps {
+		if w.WaitForIps {
+			return c.ClientConfig.WaitForVmNetworkAdaptersIps(ctx, vmName, timeout, pollPeriod, vmNetworkAdaptersWaitForIps)
+		}
+	}
+	return nil
+}
 
 // --- 純関数 (table-driven test 対象) ---
 

--- a/api/hyperv-wsman/vm_network_adapter_test.go
+++ b/api/hyperv-wsman/vm_network_adapter_test.go
@@ -1,6 +1,7 @@
 package hyperv_wsman
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -12,8 +13,9 @@ import (
 // api.HypervVmNetworkAdapterClient を実装することを検証する。
 //
 // CreateVmNetworkAdapter/GetVmNetworkAdapters/UpdateVmNetworkAdapter/DeleteVmNetworkAdapter/
-// CreateOrUpdateVmNetworkAdapters は本パッケージでシャドウイングする。
-// WaitForVmNetworkAdaptersIps は未実装で PowerShell にフォールバックする (意図的)。
+// CreateOrUpdateVmNetworkAdapters/WaitForVmNetworkAdaptersIps は本パッケージでシャドウイングする。
+// WaitForVmNetworkAdaptersIps は全 NIC が wait_for_ips=false のとき PS を省き、それ以外は
+// winrm 実装へ委譲する (#76)。
 func TestClientConfig_ImplementsHypervVmNetworkAdapterClient(t *testing.T) {
 	var c *ClientConfig
 	var _ api.HypervVmNetworkAdapterClient = c // コンパイル時チェック
@@ -25,11 +27,45 @@ func TestClientConfig_ImplementsHypervVmNetworkAdapterClient(t *testing.T) {
 		"UpdateVmNetworkAdapter",
 		"DeleteVmNetworkAdapter",
 		"CreateOrUpdateVmNetworkAdapters",
+		"WaitForVmNetworkAdaptersIps",
 	} {
 		if _, ok := cType.MethodByName(methodName); !ok {
 			t.Errorf("メソッド %s が hyperv-wsman で定義されていない (シャドウイングされない)", methodName)
 		}
 	}
+}
+
+// TestWaitForVmNetworkAdaptersIps_SkipsWhenAllFalse は #76 のスキップ判定を検証する。
+//
+// 全 NIC が wait_for_ips=false (または空リスト) なら PS を出さず nil を返す。1 つでも true が
+// あれば埋め込んだ winrm 実装へ委譲する。委譲分岐では nil 埋め込みクライアントの参照で panic
+// することを利用し、「スキップせず委譲した」ことを確定的に確認する。
+func TestWaitForVmNetworkAdaptersIps_SkipsWhenAllFalse(t *testing.T) {
+	ctx := context.Background()
+	c := &ClientConfig{} // 埋め込み winrm も WsmanClient も nil
+
+	t.Run("空リストはスキップ", func(t *testing.T) {
+		if err := c.WaitForVmNetworkAdaptersIps(ctx, "vm", 0, 0, nil); err != nil {
+			t.Errorf("空リストで PS を出さず nil を期待、got %v", err)
+		}
+	})
+
+	t.Run("全 false はスキップ", func(t *testing.T) {
+		waits := []api.VmNetworkAdapterWaitForIp{{WaitForIps: false}, {WaitForIps: false}}
+		if err := c.WaitForVmNetworkAdaptersIps(ctx, "vm", 0, 0, waits); err != nil {
+			t.Errorf("全 false で PS を出さず nil を期待、got %v", err)
+		}
+	})
+
+	t.Run("1 つでも true なら winrm へ委譲する", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("wait_for_ips=true でスキップせず winrm 実装へ委譲することを期待 (nil クライアントで panic)")
+			}
+		}()
+		waits := []api.VmNetworkAdapterWaitForIp{{WaitForIps: false}, {WaitForIps: true}}
+		_ = c.WaitForVmNetworkAdaptersIps(ctx, "vm", 0, 0, waits)
+	})
 }
 
 // TestUnsupportedNetworkAdapterOptions は既定 NIC は許可、未対応フィールドが既定外なら error。

--- a/api/vm.go
+++ b/api/vm.go
@@ -4,9 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 )
+
+// ErrVMNotFound は指定名の VM が存在しないことを表す番兵エラー。
+//
+// 「不在」を「通信障害」と区別して返すために使う。provider 層はこれを errors.Is で判定し、
+// refresh 時に不在なら state から除去 (SetId("")) して再作成をトリガーする。
+// go-wsman の hyperv.ErrVMNotFound は api 境界 (hyperv-wsman) でこの番兵へ変換し、
+// provider を go-wsman 実装から疎に保つ (VmExists と同じ変換方針)。
+var ErrVMNotFound = errors.New("hyperv: vm not found")
 
 type CriticalErrorAction int
 

--- a/internal/provider/resource_hyperv_machine_instance.go
+++ b/internal/provider/resource_hyperv_machine_instance.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -1189,9 +1190,16 @@ func resourceHyperVMachineInstanceRead(ctx context.Context, d *schema.ResourceDa
 
 	vm, err := client.GetVm(ctx, name)
 	if err != nil {
+		// go-wsman 経路は不在を api.ErrVMNotFound で返す。refresh 時に外部削除された
+		// VM は state から除去して再作成をトリガーする (winrm 経路の graceful 不在挙動と等価)。
+		if !d.IsNewResource() && errors.Is(err, api.ErrVMNotFound) {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 
+	// winrm 経路は不在時に空 Vm (Name=="") をエラーなしで返すため、こちらでも state 除去する。
 	if !d.IsNewResource() && vm.Name == "" {
 		d.SetId("")
 		return nil


### PR DESCRIPTION
## 変更内容

strict mode (PowerShell 0 件) 化の一環で 2 件の Read 経路を修正。

- **#72**: go-wsman 経路の `GetVm` が VM 不在をエラー伝播していたため、外部削除された VM の refresh がエラーで落ちていた (winrm 経路の graceful 不在挙動のリグレッション)。`api.ErrVMNotFound` 番兵を新設し、hyperv-wsman `GetVm` で go-wsman の `hyperv.ErrVMNotFound` を api 境界で変換 (VmExists と同じ方針)。provider は `errors.Is(err, api.ErrVMNotFound)` で判定して state 除去する。
- **#76**: Read が無条件に `WaitForVmNetworkAdaptersIps` (winrm=PS) を呼び、毎 refresh で PS が出ていた。wsman shadow を新設し「全 NIC が wait_for_ips=false なら PS を出さず即 return、1 つでも true なら winrm 実装へ委譲」とした。

## 設計判断

- #72 の番兵翻訳は issue 文面 (hyperv.ErrVMNotFound の直接参照) と異なり、provider を go-wsman 実装から疎に保つため api 境界で変換する既存規約 (VmExists) に合わせた。
- #76 を wsman shadow 層に置いたことで resource / data source 両方の Read が同一経路で PS 省略の恩恵を受ける。

## 検証結果

- `TestWaitForVmNetworkAdaptersIps_SkipsWhenAllFalse` を追加 (空 / 全 false / 委譲の 3 ケース)。
- `go build ./...` / `go vet ./...` / `go test ./...` 全 PASS、`gofmt` clean。

## 既知の制約 (別対応)

go-wsman の VM 名照合を大小文字非依存にする修正 (go-wsman #103 / PR r4sd/go-wsman#104) を取り込むまで、大小文字だけ異なる表示名で #72 の state 除去が誤発火しうる。go-wsman マージ後に go.mod bump で解消する。

Closes #72
Closes #76