### PR TITLE
chore(deps): go-wsman を @main に bump (#103 case-sensitivity 根治 + #106 Go1.26.5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260706144934-2bbaea5be96b
+	github.com/r4sd/go-wsman v0.0.0-20260712171908-1545b8f6bd50
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260706144934-2bbaea5be96b h1:PeOStoleuCHE95l7MjzBgKS4Vun23a6GFvMTWIhz3QY=
-github.com/r4sd/go-wsman v0.0.0-20260706144934-2bbaea5be96b/go.mod h1:4JiKL6vEo8IgXgrDCznPDgYFiScu5wzOo2DZgGIHd1I=
+github.com/r4sd/go-wsman v0.0.0-20260712171908-1545b8f6bd50 h1:xtJrrDuatXWqB7tHHEJRyrICO4CwiR0ov+x7gX9nhQk=
+github.com/r4sd/go-wsman v0.0.0-20260712171908-1545b8f6bd50/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=


### PR DESCRIPTION
## 変更内容

go.mod の go-wsman を `2bbaea5`(#101 時点)→ `1545b8f`(main)に bump。

- **#103 / PR#104**: `FindComputerSystemByElementName` の ElementName 照合を `strings.EqualFold` 化。case 違いの表示名で実在 VM を `ErrVMNotFound` 誤認する破壊経路を取り込みでクローズ。
- **#106 / PR#106**: crypto/tls ECH 脆弱性 GO-2026-5856(Go 1.26.5)の付随取り込み。

## 設計判断

純粋な依存 bump。provider 側のロジック変更なし。go directive は #74 で既に 1.26.5 のため変化なし(差分は go.mod 1 行 + go.sum のみ)。

## 検証結果

- `go build ./...` green (rc=0)
- `go test ./...` 全 pass

Closes #83