### PR TITLE
feat: gpu_adapter の Read を go-wsman 化 + Create 空リストガード (#77)

### DIFF
--- a/api/hyperv-wsman/vm_gpu_adapter.go
+++ b/api/hyperv-wsman/vm_gpu_adapter.go
@@ -1,0 +1,65 @@
+package hyperv_wsman
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// GetVmGpuAdapters は VM に割り当てられた GPU パーティションを go-wsman 経由で取得する。
+//
+// PS 版 (Get-VMGpuPartitionAdapter) をシャドウイングし、Read の無条件 PowerShell 実行を解消する。
+// GPU 未割当の VM (homelab など) では空スライスを返す (go-wsman ListGpuAdapters がホスト能力定義を
+// 除外して空を返す)。
+func (c *ClientConfig) GetVmGpuAdapters(ctx context.Context, vmName string) ([]api.VmGpuAdapter, error) {
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: GetVmGpuAdapters %q: %w", vmName, err)
+	}
+	gpus, err := c.WsmanClient.ListGpuAdapters(ctx, guid)
+	if err != nil {
+		return nil, fmt.Errorf("hyperv-wsman: GetVmGpuAdapters %q: %w", vmName, err)
+	}
+	result := make([]api.VmGpuAdapter, 0, len(gpus))
+	for _, g := range gpus {
+		result = append(result, gpuAdapterFromSettingData(vmName, g))
+	}
+	return result, nil
+}
+
+// gpuAdapterFromSettingData は go-wsman の Msvm_GpuPartitionSettingData を provider の
+// api.VmGpuAdapter に変換する純関数。全プロパティ uint64 で 1:1 に写す。
+func gpuAdapterFromSettingData(vmName string, g *hyperv.Msvm_GpuPartitionSettingData) api.VmGpuAdapter {
+	return api.VmGpuAdapter{
+		VmName:                  vmName,
+		MinPartitionVRAM:        g.MinPartitionVRAM,
+		MaxPartitionVRAM:        g.MaxPartitionVRAM,
+		OptimalPartitionVRAM:    g.OptimalPartitionVRAM,
+		MinPartitionEncode:      g.MinPartitionEncode,
+		MaxPartitionEncode:      g.MaxPartitionEncode,
+		OptimalPartitionEncode:  g.OptimalPartitionEncode,
+		MinPartitionDecode:      g.MinPartitionDecode,
+		MaxPartitionDecode:      g.MaxPartitionDecode,
+		OptimalPartitionDecode:  g.OptimalPartitionDecode,
+		MinPartitionCompute:     g.MinPartitionCompute,
+		MaxPartitionCompute:     g.MaxPartitionCompute,
+		OptimalPartitionCompute: g.OptimalPartitionCompute,
+	}
+}
+
+// CreateOrUpdateVmGpuAdapters は GPU パーティションの割当を反映する。
+//
+// 空リスト (GPU 割当なし) の時は PowerShell を流さず no-op で返す (空リストガード)。PS 版は空でも
+// Get-VMGpuPartitionAdapter + Remove を無条件実行するため、GPU 未使用の VM (homelab など) で毎回
+// PS が走っていた。この非対称を解消する。
+//
+// 非空 (GPU 割当あり) の時は go-wsman 側に Add プリミティブが未実装 (#59 の Add 部分) のため、
+// 埋め込んだ PowerShell 実装にフォールバックする。go-wsman で Add を実装したらここを差し替える。
+func (c *ClientConfig) CreateOrUpdateVmGpuAdapters(ctx context.Context, vmName string, gpuAdapters []api.VmGpuAdapter) error {
+	if len(gpuAdapters) == 0 {
+		return nil
+	}
+	return c.ClientConfig.CreateOrUpdateVmGpuAdapters(ctx, vmName, gpuAdapters)
+}

--- a/api/hyperv-wsman/vm_gpu_adapter_test.go
+++ b/api/hyperv-wsman/vm_gpu_adapter_test.go
@@ -1,0 +1,79 @@
+package hyperv_wsman
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// TestClientConfig_ImplementsHypervVmGpuAdapterClient は ClientConfig が
+// api.HypervVmGpuAdapterClient を実装し、両メソッドが本パッケージでシャドウイングされている
+// ことを検証する (埋め込み winrm から promotion されただけでは無条件 PS が解消しないため)。
+func TestClientConfig_ImplementsHypervVmGpuAdapterClient(t *testing.T) {
+	var c *ClientConfig
+	var _ api.HypervVmGpuAdapterClient = c // コンパイル時チェック
+
+	cType := reflect.TypeOf((*ClientConfig)(nil))
+	for _, methodName := range []string{"GetVmGpuAdapters", "CreateOrUpdateVmGpuAdapters"} {
+		if _, ok := cType.MethodByName(methodName); !ok {
+			t.Errorf("メソッド %s が hyperv-wsman で定義されていない (シャドウイングされない)", methodName)
+		}
+	}
+}
+
+// TestGpuAdapterFromSettingData は go-wsman の型から provider 型への変換が全 12 プロパティを
+// 桁落ちなく 1:1 に写すことを検証する。
+func TestGpuAdapterFromSettingData(t *testing.T) {
+	src := &hyperv.Msvm_GpuPartitionSettingData{
+		InstanceID:              "Microsoft:11111111\\GPUP-0",
+		MinPartitionVRAM:        80000000,
+		MaxPartitionVRAM:        100000000,
+		OptimalPartitionVRAM:    90000000,
+		MinPartitionEncode:      1,
+		MaxPartitionEncode:      18446744073709551615, // uint64 上限
+		OptimalPartitionEncode:  2,
+		MinPartitionDecode:      3,
+		MaxPartitionDecode:      4,
+		OptimalPartitionDecode:  5,
+		MinPartitionCompute:     6,
+		MaxPartitionCompute:     7,
+		OptimalPartitionCompute: 8,
+	}
+
+	got := gpuAdapterFromSettingData("my-vm", src)
+
+	want := api.VmGpuAdapter{
+		VmName:                  "my-vm",
+		MinPartitionVRAM:        80000000,
+		MaxPartitionVRAM:        100000000,
+		OptimalPartitionVRAM:    90000000,
+		MinPartitionEncode:      1,
+		MaxPartitionEncode:      18446744073709551615,
+		OptimalPartitionEncode:  2,
+		MinPartitionDecode:      3,
+		MaxPartitionDecode:      4,
+		OptimalPartitionDecode:  5,
+		MinPartitionCompute:     6,
+		MaxPartitionCompute:     7,
+		OptimalPartitionCompute: 8,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("gpuAdapterFromSettingData mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+// TestCreateOrUpdateVmGpuAdapters_EmptyGuard は空リストが PowerShell を流さず no-op で返ること
+// (空リストガード) を検証する。WsmanClient/WinRmClient を nil にした ClientConfig で呼び、
+// PS 経路や go-wsman 経路に触れず nil を返すことで「実際に何も呼んでいない」ことを保証する
+// (もし PS フォールバックや resolve が走れば nil ポインタで panic するため負の証明になる)。
+func TestCreateOrUpdateVmGpuAdapters_EmptyGuard(t *testing.T) {
+	c := &ClientConfig{} // WsmanClient も埋め込み winrm も nil
+	if err := c.CreateOrUpdateVmGpuAdapters(t.Context(), "any-vm", nil); err != nil {
+		t.Errorf("空リストは no-op であるべき: %v", err)
+	}
+	if err := c.CreateOrUpdateVmGpuAdapters(t.Context(), "any-vm", []api.VmGpuAdapter{}); err != nil {
+		t.Errorf("空スライスは no-op であるべき: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260712171908-1545b8f6bd50
+	github.com/r4sd/go-wsman v0.0.0-20260716100323-c220112bcf5c
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/r4sd/go-wsman v0.0.0-20260712171908-1545b8f6bd50 h1:xtJrrDuatXWqB7tHHEJRyrICO4CwiR0ov+x7gX9nhQk=
-github.com/r4sd/go-wsman v0.0.0-20260712171908-1545b8f6bd50/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
+github.com/r4sd/go-wsman v0.0.0-20260716100323-c220112bcf5c h1:I8nsGRZXet1UumJ1zoMSADCInxhsgYYXeZxJt3nzx3Q=
+github.com/r4sd/go-wsman v0.0.0-20260716100323-c220112bcf5c/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/gpu_read_integration_test.go
+++ b/internal/provider/gpu_read_integration_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の gpu_adapter 読み取り + 空リストガード (#77) の実機統合テスト。
+//
+// provider 層の GetVmGpuAdapters / CreateOrUpdateVmGpuAdapters を「VM 表示名」で呼び、
+// GPU 未使用の homelab で:
+//   - Read が空スライス・no-error を返す (無条件 PS の解消、resolveVMGUID→ListGpuAdapters が効く)
+//   - Create(空リスト) が PS を流さず no-op で返る (空リストガード)
+// ことを非破壊で確認する (既存 VM への読み取り + 空 Create のみ、GPU 割当は変更しない)。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	HYPERV_TEST_TARGET_VM_NAME=k8s-worker-01 \
+//	go test -tags integration ./internal/provider/ -run TestRealHostGpuReadWsman -v
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostGpuReadWsman(t *testing.T) {
+	vmName := os.Getenv("HYPERV_TEST_TARGET_VM_NAME")
+	if vmName == "" {
+		t.Skip("HYPERV_TEST_TARGET_VM_NAME 未設定 (読み取り対象の既存 VM 表示名)")
+	}
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	ctx := context.Background()
+
+	// Read: 表示名で GPU パーティションが解決・取得でき、GPU 未使用ホストで空を返すこと。
+	// (旧 PS 実装は無条件 PS。新実装は resolveVMGUID→ListGpuAdapters が能力定義を除外して空。)
+	gpus, err := cc.GetVmGpuAdapters(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmGpuAdapters(%q): %v", vmName, err)
+	}
+	t.Logf("VM %q: GpuAdapters = %d", vmName, len(gpus))
+	if len(gpus) != 0 {
+		// homelab は GPU 未使用。0 件でなければテスト前提 (または能力定義の除外) を見直す。
+		t.Errorf("GPU 未使用ホストで GpuAdapters = %d, want 0 (能力定義混入 or 前提崩れ)", len(gpus))
+	}
+
+	// Create(空リスト): 空リストガードで PS を流さず no-op で返ること (非破壊)。
+	if err := cc.CreateOrUpdateVmGpuAdapters(ctx, vmName, []api.VmGpuAdapter{}); err != nil {
+		t.Errorf("CreateOrUpdateVmGpuAdapters(空): no-op であるべき: %v", err)
+	}
+}


### PR DESCRIPTION
## 変更内容

`GetVmGpuAdapters` / `CreateOrUpdateVmGpuAdapters` の無条件 PowerShell 実行を解消する (v2.0 残 4→3 件)。

- **GetVmGpuAdapters**: `resolveVMGUID` → go-wsman `ListGpuAdapters` で GPU パーティションを取得。GPU 未使用 VM では空スライスを返す (ホスト能力定義 `Microsoft:Definition\...` は go-wsman 側で除外済)。
- **CreateOrUpdateVmGpuAdapters**: 空リストガードを追加。空 (GPU 割当なし) は PS を流さず no-op。PS 版は空でも `Get-VMGpuPartitionAdapter` + `Remove` を無条件実行し、`integration_service` の Go ループ no-op と非対称だった。非空は go-wsman Add 未実装 (#59) のため埋め込み PS にフォールバック。
- go-wsman を `@main` に bump (`ListGpuAdapters` プリミティブ go-wsman #107 を取り込み)。

## 設計判断

- **空リストガードのみ (Add は PS 据え置き)**: go-wsman #59 の Add/SR-IOV は未実装。#77 のスコープは「Read の go-wsman 化 + Create 空リストの無条件 PS 解消」であり、非空 GPU 割当 (homelab では発生しない) は PS フォールバックで既存挙動を維持する。
- **能力定義の除外は go-wsman 層で完結**: enumerate が返すホスト能力定義は `matchSettingDataVM` の VM_GUID 前方一致で除外され、provider は VM 割当のみを受け取る。

## 検証結果

- **unit**: 純関数の table-driven test (12 プロパティ 1:1 変換 / uint64 上限桁落ちなし) / 空リストガードの no-op test (nil client で PS・go-wsman 経路に触れないことを負の証明) / shadow 定義の reflect チェック。
- **実機 acc test** (homelab k8s-worker-01): `GetVmGpuAdapters` = 0 件・no-error、`CreateOrUpdateVmGpuAdapters(空)` = no-op を実証。
- `go build ./...` / `go test ./...` green。

Closes #77