### PR TITLE
docs: Fable レビューは結論優先で依頼する旨を DoD に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ framework。Slice A(vm_processor write)を型として蒸留(2026-07-19)。**新
 - [ ] **TDD 先行**: RED を確認してから実装(`feedback_tdd_first_default` (memory))。
 - [ ] コメントは **WHY**(単位・契約・非自明な制約)。コードを言い換える WHAT は書かない。
 - [ ] 実機 acc test を **1 回は実行して GREEN を確認**(CI 非実行のためログを PR に残す)。
-- [ ] **Fable 敵対レビュー**を実施し、致命指摘は merge 前に反映。
+- [ ] **Fable 敵対レビュー**を実施し、致命指摘は merge 前に反映。**プロンプトは過度な手順書きをせず、判定(CONFIRMED/REFUTED等)と結論を求める形にする**(Fable 系モデルは非手続き的な指示の方が出力品質が高い。手順は Claude 側=このパイプラインの実行者が担い、Fable には「何を検証するか」だけ渡す)。
 
 ## 4. この型が固めた shadow 特有の設計ルール(再発防止)
 


### PR DESCRIPTION
## 概要

Fable(`claude-fable-5`)の公式移行ガイドが明言する挙動を DoD に反映する:「旧モデル向けに書かれた過度に手続き的なプロンプトは出力品質を下げる」。

## 変更内容

`## 3. Soft rule` の「Fable 敵対レビュー」項目に、プロンプトは判定(CONFIRMED/REFUTED 等)と結論を求める形にする旨を追記。手順は Claude(実行者)側が担い、Fable には「何を検証するか」だけ渡す。

## 全体見直しは不要と判断(リサーチ後に確認)

縦スライスの①〜⑦手順は Claude が実行する作業手順で Fable には渡らないため、DoD 全体の書き直しは不要。あわせて確認した以下も変更不要:
- リーン化(~200行目安): provider 82行 / go-wsman 163行で既に基準内
- WHY優先・機械強制と規約の分離: 既存の Hard gate / Soft rule 分離で対応済み
- AGENTS.md: Claude Code 未対応(Issue #31005、Anthropic 公式回答ゼロ)。静観

ドキュメントのみ、コード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)