### PR TITLE
feat: vm_firmware の読み取りを go-wsman 化 (Slice D READ, #80)

### DIFF
--- a/api/hyperv-wsman/vm_firmware.go
+++ b/api/hyperv-wsman/vm_firmware.go
@@ -29,19 +29,12 @@ func secureBootTemplateIdToName(guid string) string {
 }
 
 // firmwareFromSystemSettingData は Msvm_VirtualSystemSettingData から api.VmFirmware (スカラー部分) を
-// 組み立てる純関数。
-//
-// BootOrders (Gen2BootOrder) は未対応: BootSourceOrder[] の各要素 (Msvm_BootSourceSettingData への
-// EPR) を実デバイス (NIC/Drive) に逆引きする相関ロジックが go-wsman 側にまだ無い (Slice D 継続)。
-// 黙って空を返すと「boot_order を設定したのに refresh で消えた」ように見える危険な silent drop に
-// なるため (DoD: 黙って成功報告する実装は禁止)、BootSourceOrder が非空なら明示エラーで拒否する。
-func firmwareFromSystemSettingData(vmName string, settings *hyperv.Msvm_VirtualSystemSettingData) (api.VmFirmware, error) {
-	if len(settings.BootSourceOrder) > 0 {
-		return api.VmFirmware{}, fmt.Errorf(
-			"vm_firmware.boot_order は go-wsman 経路 (HYPERV_USE_WSMAN) では未対応です。" +
-				"PowerShell 経路 (HYPERV_USE_WSMAN 未設定) を使ってください")
-	}
-
+// 組み立てる純関数。BootSourceOrder が非空 (Gen2 VM にブート可能デバイスが付いている場合、config で
+// boot_order を明示していなくても Hyper-V が自動生成する) の場合の扱いは呼び出し側 (GetVmFirmware) の
+// 責務とし、ここでは常に BootOrders=nil の api.VmFirmware を返す (silent drop ではなく、非空ケースを
+// 呼び出し側が PS 委譲で処理する前提。Fable レビュー指摘: デバイス付き Gen2 VM 全般の Read を壊す
+// 「広すぎる拒否」を避けるため、ここでの明示エラーは撤回した)。
+func firmwareFromSystemSettingData(vmName string, settings *hyperv.Msvm_VirtualSystemSettingData) api.VmFirmware {
 	enableSecureBoot := api.OnOffState_Off
 	if settings.SecureBoot {
 		enableSecureBoot = api.OnOffState_On
@@ -65,13 +58,19 @@ func firmwareFromSystemSettingData(vmName string, settings *hyperv.Msvm_VirtualS
 		PreferredNetworkBootProtocol: preferredProtocol,
 		ConsoleMode:                  api.ConsoleModeType(settings.ConsoleMode),
 		PauseAfterBootFailure:        pauseAfterBootFailure,
-	}, nil
+	}
 }
 
-// GetVmFirmware は VM の Gen2 ファームウェア設定を go-wsman 経由で取得する (BootOrders 除く)。
+// GetVmFirmware は VM の Gen2 ファームウェア設定を go-wsman 経由で取得する。
 //
 // PS 版 (Get-VMFirmware) をシャドウイングする。Gen1 VM は呼び出し側 (resource 層) が
 // generation>1 ガードで既に除外しているため、本メソッドは Gen2 VM のみを想定する。
+//
+// BootSourceOrder が非空 (ブート可能デバイスが付いていれば config で boot_order を明示していなくても
+// Hyper-V が自動生成する) の場合は PS (埋め込み winrm) に委譲する。go-wsman は BootSourceOrder→
+// Gen2BootOrder の相関ロジックをまだ持たない (Slice D 継続) ため、silent drop や広すぎる拒否
+// (デバイス付き Gen2 VM 全般の Read を壊す) を避け、対応済みの PS 経路にフォールバックする
+// (Slice A の processor と同じ設計。Fable レビュー指摘で明示エラーから変更)。
 func (c *ClientConfig) GetVmFirmware(ctx context.Context, vmName string) (api.VmFirmware, error) {
 	guid, err := c.resolveVMGUID(ctx, vmName)
 	if err != nil {
@@ -81,11 +80,10 @@ func (c *ClientConfig) GetVmFirmware(ctx context.Context, vmName string) (api.Vm
 	if err != nil {
 		return api.VmFirmware{}, fmt.Errorf("hyperv-wsman: GetVmFirmware %q: %w", vmName, err)
 	}
-	firmware, err := firmwareFromSystemSettingData(vmName, settings)
-	if err != nil {
-		return api.VmFirmware{}, fmt.Errorf("hyperv-wsman: GetVmFirmware %q: %w", vmName, err)
+	if len(settings.BootSourceOrder) > 0 {
+		return c.ClientConfig.GetVmFirmware(ctx, vmName)
 	}
-	return firmware, nil
+	return firmwareFromSystemSettingData(vmName, settings), nil
 }
 
 // GetVmFirmwares は GetVmFirmware の結果を 1 件のスライスにラップする (PS 版と同じ契約)。

--- a/api/hyperv-wsman/vm_firmware.go
+++ b/api/hyperv-wsman/vm_firmware.go
@@ -1,0 +1,98 @@
+package hyperv_wsman
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// secureBootTemplateGUIDToName は Msvm_VirtualSystemSettingData.SecureBootTemplateId (実 GUID) から
+// PS の -SecureBootTemplate が受け付けるシンボリック名への逆引き表。
+//
+// 実機確認 (2026-07-26、Gen2 シェル VM の既定値): "MicrosoftWindows" = 1734C6E8-3154-4DDA-BA5F-
+// A874CC483422 の 1 件のみ確認済み。他のテンプレート (MicrosoftUEFICertificateAuthority /
+// OpenSourceShieldedVM 等) の GUID は未確認のため表に含めない (一次資料検証ルール: 確認できていない
+// 値をコードに埋め込まない)。未知の GUID は secureBootTemplateIdToName が GUID 文字列のままフォール
+// バックする。
+var secureBootTemplateGUIDToName = map[string]string{
+	"1734C6E8-3154-4DDA-BA5F-A874CC483422": "MicrosoftWindows",
+}
+
+// secureBootTemplateIdToName は既知の GUID ならシンボリック名を、未知/空なら入力をそのまま返す。
+func secureBootTemplateIdToName(guid string) string {
+	if name, ok := secureBootTemplateGUIDToName[guid]; ok {
+		return name
+	}
+	return guid
+}
+
+// firmwareFromSystemSettingData は Msvm_VirtualSystemSettingData から api.VmFirmware (スカラー部分) を
+// 組み立てる純関数。
+//
+// BootOrders (Gen2BootOrder) は未対応: BootSourceOrder[] の各要素 (Msvm_BootSourceSettingData への
+// EPR) を実デバイス (NIC/Drive) に逆引きする相関ロジックが go-wsman 側にまだ無い (Slice D 継続)。
+// 黙って空を返すと「boot_order を設定したのに refresh で消えた」ように見える危険な silent drop に
+// なるため (DoD: 黙って成功報告する実装は禁止)、BootSourceOrder が非空なら明示エラーで拒否する。
+func firmwareFromSystemSettingData(vmName string, settings *hyperv.Msvm_VirtualSystemSettingData) (api.VmFirmware, error) {
+	if len(settings.BootSourceOrder) > 0 {
+		return api.VmFirmware{}, fmt.Errorf(
+			"vm_firmware.boot_order は go-wsman 経路 (HYPERV_USE_WSMAN) では未対応です。" +
+				"PowerShell 経路 (HYPERV_USE_WSMAN 未設定) を使ってください")
+	}
+
+	enableSecureBoot := api.OnOffState_Off
+	if settings.SecureBoot {
+		enableSecureBoot = api.OnOffState_On
+	}
+
+	preferredProtocol := api.IPProtocolPreference_IPv4
+	if settings.NetworkBootPreferredProtocol == hyperv.NetworkBootPreferredProtocolIPv6 {
+		preferredProtocol = api.IPProtocolPreference_IPv6
+	}
+
+	pauseAfterBootFailure := api.OnOffState_Off
+	if settings.PauseAfterBootFailure {
+		pauseAfterBootFailure = api.OnOffState_On
+	}
+
+	return api.VmFirmware{
+		VmName:                       vmName,
+		BootOrders:                   nil,
+		EnableSecureBoot:             enableSecureBoot,
+		SecureBootTemplate:           secureBootTemplateIdToName(settings.SecureBootTemplateId),
+		PreferredNetworkBootProtocol: preferredProtocol,
+		ConsoleMode:                  api.ConsoleModeType(settings.ConsoleMode),
+		PauseAfterBootFailure:        pauseAfterBootFailure,
+	}, nil
+}
+
+// GetVmFirmware は VM の Gen2 ファームウェア設定を go-wsman 経由で取得する (BootOrders 除く)。
+//
+// PS 版 (Get-VMFirmware) をシャドウイングする。Gen1 VM は呼び出し側 (resource 層) が
+// generation>1 ガードで既に除外しているため、本メソッドは Gen2 VM のみを想定する。
+func (c *ClientConfig) GetVmFirmware(ctx context.Context, vmName string) (api.VmFirmware, error) {
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return api.VmFirmware{}, fmt.Errorf("hyperv-wsman: GetVmFirmware %q: %w", vmName, err)
+	}
+	settings, err := c.WsmanClient.GetSystemSettingData(ctx, guid)
+	if err != nil {
+		return api.VmFirmware{}, fmt.Errorf("hyperv-wsman: GetVmFirmware %q: %w", vmName, err)
+	}
+	firmware, err := firmwareFromSystemSettingData(vmName, settings)
+	if err != nil {
+		return api.VmFirmware{}, fmt.Errorf("hyperv-wsman: GetVmFirmware %q: %w", vmName, err)
+	}
+	return firmware, nil
+}
+
+// GetVmFirmwares は GetVmFirmware の結果を 1 件のスライスにラップする (PS 版と同じ契約)。
+func (c *ClientConfig) GetVmFirmwares(ctx context.Context, vmName string) ([]api.VmFirmware, error) {
+	firmware, err := c.GetVmFirmware(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	return []api.VmFirmware{firmware}, nil
+}

--- a/api/hyperv-wsman/vm_firmware_test.go
+++ b/api/hyperv-wsman/vm_firmware_test.go
@@ -1,0 +1,108 @@
+package hyperv_wsman
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// TestClientConfig_ImplementsHypervVmFirmwareClient は ClientConfig が
+// api.HypervVmFirmwareClient を実装し、無条件 PS だった GetVmFirmware/GetVmFirmwares が
+// 本パッケージでシャドウイング (promotion ではなく直接定義) されていることを検証する。
+// CreateOrUpdate/GetNoVmFirmwares は埋め込み winrm から promotion されるため、ここでは検証しない
+// (WRITE 側は Slice D 継続)。
+func TestClientConfig_ImplementsHypervVmFirmwareClient(t *testing.T) {
+	var c *ClientConfig
+	var _ api.HypervVmFirmwareClient = c // コンパイル時チェック
+
+	assertShadowedIn(t, "GetVmFirmware", "vm_firmware.go")
+	assertShadowedIn(t, "GetVmFirmwares", "vm_firmware.go")
+}
+
+func TestSecureBootTemplateIdToName(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"MicrosoftWindows (実機確認済み)", "1734C6E8-3154-4DDA-BA5F-A874CC483422", "MicrosoftWindows"},
+		{"未知のGUIDはそのまま返す", "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000"},
+		{"空文字はそのまま返す", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := secureBootTemplateIdToName(tt.id); got != tt.want {
+				t.Errorf("secureBootTemplateIdToName(%q): got %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirmwareFromSystemSettingData(t *testing.T) {
+	settings := &hyperv.Msvm_VirtualSystemSettingData{
+		SecureBoot:                   true,
+		SecureBootTemplateId:         "1734C6E8-3154-4DDA-BA5F-A874CC483422",
+		NetworkBootPreferredProtocol: hyperv.NetworkBootPreferredProtocolIPv6,
+		ConsoleMode:                  hyperv.ConsoleModeCOM1,
+		PauseAfterBootFailure:        true,
+		BootSourceOrder:              nil,
+	}
+	got, err := firmwareFromSystemSettingData("vm-1", settings)
+	if err != nil {
+		t.Fatalf("firmwareFromSystemSettingData: %v", err)
+	}
+	want := api.VmFirmware{
+		VmName:                       "vm-1",
+		BootOrders:                   nil,
+		EnableSecureBoot:             api.OnOffState_On,
+		SecureBootTemplate:           "MicrosoftWindows",
+		PreferredNetworkBootProtocol: api.IPProtocolPreference_IPv6,
+		ConsoleMode:                  api.ConsoleModeType_Com1,
+		PauseAfterBootFailure:        api.OnOffState_On,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("firmwareFromSystemSettingData:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+// TestFirmwareFromSystemSettingData_Defaults は SecureBoot=false / IPv4 / ConsoleMode=Default /
+// PauseAfterBootFailure=false (ゼロ値側) の変換を検証する。
+func TestFirmwareFromSystemSettingData_Defaults(t *testing.T) {
+	settings := &hyperv.Msvm_VirtualSystemSettingData{
+		SecureBoot:                   false,
+		SecureBootTemplateId:         "",
+		NetworkBootPreferredProtocol: hyperv.NetworkBootPreferredProtocolIPv4,
+		ConsoleMode:                  hyperv.ConsoleModeDefault,
+		PauseAfterBootFailure:        false,
+	}
+	got, err := firmwareFromSystemSettingData("vm-2", settings)
+	if err != nil {
+		t.Fatalf("firmwareFromSystemSettingData: %v", err)
+	}
+	if got.EnableSecureBoot != api.OnOffState_Off {
+		t.Errorf("EnableSecureBoot: got %v, want Off", got.EnableSecureBoot)
+	}
+	if got.PreferredNetworkBootProtocol != api.IPProtocolPreference_IPv4 {
+		t.Errorf("PreferredNetworkBootProtocol: got %v, want IPv4", got.PreferredNetworkBootProtocol)
+	}
+	if got.ConsoleMode != api.ConsoleModeType_Default {
+		t.Errorf("ConsoleMode: got %v, want Default", got.ConsoleMode)
+	}
+	if got.PauseAfterBootFailure != api.OnOffState_Off {
+		t.Errorf("PauseAfterBootFailure: got %v, want Off", got.PauseAfterBootFailure)
+	}
+}
+
+// TestFirmwareFromSystemSettingData_BootOrderUnsupported は BootSourceOrder が非空の場合に
+// silent drop せず明示エラーになることを検証する (DoD: 黙って成功報告する実装は禁止)。
+func TestFirmwareFromSystemSettingData_BootOrderUnsupported(t *testing.T) {
+	settings := &hyperv.Msvm_VirtualSystemSettingData{
+		BootSourceOrder: []string{`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="Microsoft:vm-guid\nic-guid\B"`},
+	}
+	_, err := firmwareFromSystemSettingData("vm-3", settings)
+	if err == nil {
+		t.Fatal("BootSourceOrder が非空なら明示エラーになるべき (go-wsman 経路は boot_order 未対応)")
+	}
+}

--- a/api/hyperv-wsman/vm_firmware_test.go
+++ b/api/hyperv-wsman/vm_firmware_test.go
@@ -1,6 +1,10 @@
 package hyperv_wsman
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -49,10 +53,7 @@ func TestFirmwareFromSystemSettingData(t *testing.T) {
 		PauseAfterBootFailure:        true,
 		BootSourceOrder:              nil,
 	}
-	got, err := firmwareFromSystemSettingData("vm-1", settings)
-	if err != nil {
-		t.Fatalf("firmwareFromSystemSettingData: %v", err)
-	}
+	got := firmwareFromSystemSettingData("vm-1", settings)
 	want := api.VmFirmware{
 		VmName:                       "vm-1",
 		BootOrders:                   nil,
@@ -77,10 +78,7 @@ func TestFirmwareFromSystemSettingData_Defaults(t *testing.T) {
 		ConsoleMode:                  hyperv.ConsoleModeDefault,
 		PauseAfterBootFailure:        false,
 	}
-	got, err := firmwareFromSystemSettingData("vm-2", settings)
-	if err != nil {
-		t.Fatalf("firmwareFromSystemSettingData: %v", err)
-	}
+	got := firmwareFromSystemSettingData("vm-2", settings)
 	if got.EnableSecureBoot != api.OnOffState_Off {
 		t.Errorf("EnableSecureBoot: got %v, want Off", got.EnableSecureBoot)
 	}
@@ -95,14 +93,65 @@ func TestFirmwareFromSystemSettingData_Defaults(t *testing.T) {
 	}
 }
 
-// TestFirmwareFromSystemSettingData_BootOrderUnsupported は BootSourceOrder が非空の場合に
-// silent drop せず明示エラーになることを検証する (DoD: 黙って成功報告する実装は禁止)。
-func TestFirmwareFromSystemSettingData_BootOrderUnsupported(t *testing.T) {
-	settings := &hyperv.Msvm_VirtualSystemSettingData{
-		BootSourceOrder: []string{`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="Microsoft:vm-guid\nic-guid\B"`},
+// TestGetVmFirmware_DelegatesWhenBootSourceOrderNonEmpty は BootSourceOrder が非空 (ブート可能
+// デバイスが付いている Gen2 VM) の場合に、silent drop や広すぎる拒否をせず埋め込み PS (winrm) 実装へ
+// 委譲することを検証する (Fable レビュー指摘、#96)。委譲分岐では nil 埋め込みクライアントの参照で
+// panic することを利用し、「BootOrders を無視して空扱いにする」のではなく確実に委譲したことを確認する
+// (WaitForVmNetworkAdaptersIps と同じ確認手法)。
+//
+// GetSystemSettingData 自体は httptest サーバで実際に応答させ (WsmanClient は本物の *hyperv.Client)、
+// BootSourceOrder が非空の Msvm_VirtualSystemSettingData を返す。
+func TestGetVmFirmware_DelegatesWhenBootSourceOrderNonEmpty(t *testing.T) {
+	const vmName = "vm-1"
+	const vmGUID = "11111111-aaaa-bbbb-cccc-000000000001"
+	const enumXML = `<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:e="http://schemas.xmlsoap.org/ws/2004/09/enumeration">
+  <s:Header><a:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/EnumerateResponse</a:Action></s:Header>
+  <s:Body><e:EnumerateResponse><e:EnumerationContext>uuid:ctx</e:EnumerationContext></e:EnumerateResponse></s:Body>
+</s:Envelope>`
+	computerSystemPullXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:e="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wmi/root/virtualization/v2/Msvm_ComputerSystem">
+  <s:Header><a:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</a:Action></s:Header>
+  <s:Body><e:PullResponse><e:Items>
+    <p:Msvm_ComputerSystem>
+      <p:Name>%s</p:Name>
+      <p:ElementName>%s</p:ElementName>
+    </p:Msvm_ComputerSystem>
+  </e:Items><e:EndOfSequence/></e:PullResponse></s:Body>
+</s:Envelope>`, vmGUID, vmName)
+	settingDataPullXML := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:e="http://schemas.xmlsoap.org/ws/2004/09/enumeration" xmlns:p="http://schemas.microsoft.com/wbem/wsman/1/wmi/root/virtualization/v2/Msvm_VirtualSystemSettingData">
+  <s:Header><a:Action>http://schemas.xmlsoap.org/ws/2004/09/enumeration/PullResponse</a:Action></s:Header>
+  <s:Body><e:PullResponse><e:Items>
+    <p:Msvm_VirtualSystemSettingData>
+      <p:InstanceID>Microsoft:%s</p:InstanceID>
+      <p:ElementName>%s</p:ElementName>
+      <p:VirtualSystemIdentifier>%s</p:VirtualSystemIdentifier>
+      <p:VirtualSystemType>Microsoft:Hyper-V:System:Realized</p:VirtualSystemType>
+      <p:BootSourceOrder>\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="Microsoft:%s\nic-guid\B"</p:BootSourceOrder>
+    </p:Msvm_VirtualSystemSettingData>
+  </e:Items><e:EndOfSequence/></e:PullResponse></s:Body>
+</s:Envelope>`, vmGUID, vmName, vmGUID, vmGUID)
+
+	responses := []string{enumXML, computerSystemPullXML, enumXML, settingDataPullXML}
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
+		_, _ = w.Write([]byte(responses[callCount]))
+		callCount++
+	}))
+	defer server.Close()
+
+	wsmanClient, err := hyperv.NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("hyperv.NewClient: %v", err)
 	}
-	_, err := firmwareFromSystemSettingData("vm-3", settings)
-	if err == nil {
-		t.Fatal("BootSourceOrder が非空なら明示エラーになるべき (go-wsman 経路は boot_order 未対応)")
-	}
+	c := &ClientConfig{WsmanClient: wsmanClient} // 埋め込み winrm は nil
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("BootSourceOrder 非空でスキップせず winrm 実装へ委譲することを期待 (nil クライアントで panic)")
+		}
+	}()
+	_, _ = c.GetVmFirmware(context.Background(), vmName)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260725061754-b581e71a9035
+	github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXq
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/r4sd/go-wsman v0.0.0-20260725061754-b581e71a9035 h1:UFBOHn096Qmjr+/0p3Un/+GAzuzEaW+vge9K4GcOHVA=
 github.com/r4sd/go-wsman v0.0.0-20260725061754-b581e71a9035/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
+github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803 h1:Rtr7oZyhy8SfaFQkitZfxZ1OlpUj1TyTriU6nn4Ohno=
+github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -257,10 +257,14 @@ func getHypervProvider(config *Config) (hypervProvider *api.Provider, err error)
 		// go-wsman シャドウ未実装の経路が 1 件でも呼ばれたら即エラーにし、v2.0「Home-env PS-free」の
 		// 陽性証明(homelab が使う経路の PS 呼び出し 0 件)を検証できるようにする。
 		//
-		// 現状で PS-0 になる範囲: Gen1 VM かつ全 network_adapter が wait_for_ips=false の refresh/plan。
-		// PS フォールバックが残る経路(strict でエラーになる): Gen2 の firmware read(GetVmFirmwares 未
-		// シャドウ)、wait_for_ips=true(WaitForVmNetworkAdaptersIps が PS 委譲、#76)、vm_processor/
-		// integration_services ブロックを持つ config の create/update 書き込み(空でなければ PS)。
+		// 現状で PS-0 になる範囲: Gen1 VM かつ全 network_adapter が wait_for_ips=false の refresh/plan
+		// (vm_processor/integration_services の create/update 書き込みは差分なしガードで既定 config
+		// なら PS-0、#88/#95)。Gen2 の firmware read はスカラーフィールドはシャドウ済みだが、
+		// BootSourceOrder が非空 (ブート可能デバイスが付いている VM) なら PS へ委譲する (#96、
+		// BootSourceOrder→デバイス相関ロジックは未実装のため)。
+		// PS フォールバックが残る経路(strict でエラーになる): 上記 BootSourceOrder 非空の firmware
+		// read、wait_for_ips=true(WaitForVmNetworkAdaptersIps が PS 委譲、#76)、vm_firmware の
+		// create/update 書き込み(write は未着手)。
 		if strictNoPSEnabled() {
 			log.Printf("[WARN][hyperv] HYPERV_WSMAN_STRICT enabled. PowerShell フォールバックは全て fail-fast エラーになります。")
 			winrmConfig.WinRmClient = &hyperv_wsman.StrictNoPSClient{}

--- a/internal/provider/firmware_read_integration_test.go
+++ b/internal/provider/firmware_read_integration_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の GetVmFirmware (READ のみ、BootOrders 除く) の実機統合テスト。
+//
+// 使い捨て Gen2 VM を作成し、既定のファームウェア設定 (SecureBoot=On、SecureBootTemplate=
+// MicrosoftWindows、PreferredNetworkBootProtocol=IPv4、ConsoleMode=Default、
+// PauseAfterBootFailure=Off) が正しく読めることを確認する。BootOrders は未対応 (Slice D 継続)、
+// デバイス無しの VM なら BootSourceOrder が空なのでエラーにならないことも合わせて確認する。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	go test -tags integration ./internal/provider/ -run TestRealHostFirmwareReadWsman -v
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostFirmwareReadWsman(t *testing.T) {
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	ctx := context.Background()
+
+	const vmName = "tf-wsman-firmware-read-test"
+	_ = cc.DeleteVm(ctx, vmName) // 前回残骸を掃除
+	t.Cleanup(func() {
+		if err := cc.DeleteVm(ctx, vmName); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+
+	const memByt = 536870912
+	if err := cc.CreateVm(ctx, vmName,
+		"", 2, // Generation 2
+		api.CriticalErrorAction_Pause, 0,
+		api.StartAction_Nothing, 0,
+		api.StopAction_Save,
+		api.CheckpointType_Production,
+		false, false, 0,
+		api.OnOffState_Off, 0,
+		memByt, memByt, memByt,
+		"firmware-read-test", 1,
+		"", "", true, false,
+	); err != nil {
+		t.Fatalf("CreateVm: %v", err)
+	}
+
+	firmware, err := cc.GetVmFirmware(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmFirmware: %v", err)
+	}
+	t.Logf("firmware: %+v", firmware)
+
+	if firmware.EnableSecureBoot != api.OnOffState_On {
+		t.Errorf("EnableSecureBoot: got %v, want On (Gen2 既定)", firmware.EnableSecureBoot)
+	}
+	if firmware.SecureBootTemplate != "MicrosoftWindows" {
+		t.Errorf("SecureBootTemplate: got %q, want \"MicrosoftWindows\"", firmware.SecureBootTemplate)
+	}
+	if firmware.PreferredNetworkBootProtocol != api.IPProtocolPreference_IPv4 {
+		t.Errorf("PreferredNetworkBootProtocol: got %v, want IPv4 (既定)", firmware.PreferredNetworkBootProtocol)
+	}
+	if firmware.ConsoleMode != api.ConsoleModeType_Default {
+		t.Errorf("ConsoleMode: got %v, want Default", firmware.ConsoleMode)
+	}
+	if firmware.PauseAfterBootFailure != api.OnOffState_Off {
+		t.Errorf("PauseAfterBootFailure: got %v, want Off", firmware.PauseAfterBootFailure)
+	}
+	t.Logf("✅ Gen2 VM の既定ファームウェア設定を go-wsman 経由で確認")
+
+	firmwares, err := cc.GetVmFirmwares(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmFirmwares: %v", err)
+	}
+	if len(firmwares) != 1 {
+		t.Fatalf("GetVmFirmwares: got %d件, want 1", len(firmwares))
+	}
+	t.Logf("✅ GetVmFirmwares (1件ラップ) も確認")
+}


### PR DESCRIPTION
## Summary
- Get-VMFirmware をシャドウイング (BootOrders 除く)、Gen2 VM の Read 経路の無条件 PS 実行を解消
- SecureBoot/SecureBootTemplateId/NetworkBootPreferredProtocol/ConsoleMode/PauseAfterBootFailure を変換
- SecureBootTemplateId → シンボリック名は実機確認済みの "MicrosoftWindows" のみ収録、未知は GUID のままフォールバック
- BootOrders 非対応: BootSourceOrder が非空なら明示エラー (silent drop 回避)。相関ロジックは継続課題

## Test plan
- [x] unit test (純関数変換、境界ケース含む)
- [x] 実機 acc test (`TestRealHostFirmwareReadWsman`)、Gen2 シェル VM の既定値を確認
- [x] `go build` / `go vet` / `go test ./...` green