### PR TITLE
feat: BootSourceOrder→Gen2BootOrder 相関ロジック (Slice D READ 完成, #80)

### DIFF
--- a/api/hyperv-wsman/vm_firmware.go
+++ b/api/hyperv-wsman/vm_firmware.go
@@ -66,11 +66,10 @@ func firmwareFromSystemSettingData(vmName string, settings *hyperv.Msvm_VirtualS
 // PS 版 (Get-VMFirmware) をシャドウイングする。Gen1 VM は呼び出し側 (resource 層) が
 // generation>1 ガードで既に除外しているため、本メソッドは Gen2 VM のみを想定する。
 //
-// BootSourceOrder が非空 (ブート可能デバイスが付いていれば config で boot_order を明示していなくても
-// Hyper-V が自動生成する) の場合は PS (埋め込み winrm) に委譲する。go-wsman は BootSourceOrder→
-// Gen2BootOrder の相関ロジックをまだ持たない (Slice D 継続) ため、silent drop や広すぎる拒否
-// (デバイス付き Gen2 VM 全般の Read を壊す) を避け、対応済みの PS 経路にフォールバックする
-// (Slice A の processor と同じ設計。Fable レビュー指摘で明示エラーから変更)。
+// BootSourceOrder が非空の場合、NIC/DVD/HardDisk の一覧を取得して resolveBootOrders で相関解決する
+// (実機確認済みの対応関係、vm_firmware_bootorder.go 参照)。相関が失敗する場合 (未知の BootSourceType
+// や、参照先デバイスが現在の一覧に見つからない等の想定外ケース) は PS (埋め込み winrm) に委譲する
+// (Slice A の processor と同じ「go-wsman で表現できないケースは PS フォールバック」設計)。
 func (c *ClientConfig) GetVmFirmware(ctx context.Context, vmName string) (api.VmFirmware, error) {
 	guid, err := c.resolveVMGUID(ctx, vmName)
 	if err != nil {
@@ -80,10 +79,40 @@ func (c *ClientConfig) GetVmFirmware(ctx context.Context, vmName string) (api.Vm
 	if err != nil {
 		return api.VmFirmware{}, fmt.Errorf("hyperv-wsman: GetVmFirmware %q: %w", vmName, err)
 	}
-	if len(settings.BootSourceOrder) > 0 {
+
+	firmware := firmwareFromSystemSettingData(vmName, settings)
+	if len(settings.BootSourceOrder) == 0 {
+		return firmware, nil
+	}
+
+	bootOrders, err := c.resolveBootOrdersForVM(ctx, vmName, guid, settings.BootSourceOrder)
+	if err != nil {
 		return c.ClientConfig.GetVmFirmware(ctx, vmName)
 	}
-	return firmwareFromSystemSettingData(vmName, settings), nil
+	firmware.BootOrders = bootOrders
+	return firmware, nil
+}
+
+// resolveBootOrdersForVM は VM の NIC/DVD/HardDisk 一覧と Msvm_BootSourceSettingData を取得し、
+// resolveBootOrders に渡すための材料を揃える。
+func (c *ClientConfig) resolveBootOrdersForVM(ctx context.Context, vmName, guid string, bootSourceOrder []string) ([]api.Gen2BootOrder, error) {
+	bootSources, err := c.WsmanClient.ListBootSources(ctx, guid)
+	if err != nil {
+		return nil, err
+	}
+	nicRefs, err := c.getNetworkAdapterRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	dvdRefs, err := c.getDvdDriveRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	diskRefs, err := c.getHardDiskDriveRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	return resolveBootOrders(bootSourceOrder, bootSources, nicRefs, dvdRefs, diskRefs)
 }
 
 // GetVmFirmwares は GetVmFirmware の結果を 1 件のスライスにラップする (PS 版と同じ契約)。

--- a/api/hyperv-wsman/vm_firmware.go
+++ b/api/hyperv-wsman/vm_firmware.go
@@ -3,21 +3,23 @@ package hyperv_wsman
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/r4sd/go-wsman/hyperv"
 	"github.com/taliesins/terraform-provider-hyperv/api"
 )
 
+// secureBootTemplateMicrosoftWindowsGUID は Hyper-V の "MicrosoftWindows" Secure Boot テンプレートの
+// 固定識別子(全 Hyper-V 環境で共通、秘密情報ではない)。実機確認済み(2026-07-26、Gen2 シェル VM の
+// 既定値)。他のテンプレート(MicrosoftUEFICertificateAuthority / OpenSourceShieldedVM 等)の GUID は
+// 未確認のため表に含めない(一次資料検証ルール: 確認できていない値をコードに埋め込まない)。
+const secureBootTemplateMicrosoftWindowsGUID = "1734C6E8-3154-4DDA-BA5F-A874CC483422"
+
 // secureBootTemplateGUIDToName は Msvm_VirtualSystemSettingData.SecureBootTemplateId (実 GUID) から
-// PS の -SecureBootTemplate が受け付けるシンボリック名への逆引き表。
-//
-// 実機確認 (2026-07-26、Gen2 シェル VM の既定値): "MicrosoftWindows" = 1734C6E8-3154-4DDA-BA5F-
-// A874CC483422 の 1 件のみ確認済み。他のテンプレート (MicrosoftUEFICertificateAuthority /
-// OpenSourceShieldedVM 等) の GUID は未確認のため表に含めない (一次資料検証ルール: 確認できていない
-// 値をコードに埋め込まない)。未知の GUID は secureBootTemplateIdToName が GUID 文字列のままフォール
-// バックする。
+// PS の -SecureBootTemplate が受け付けるシンボリック名への逆引き表。未知の GUID は
+// secureBootTemplateIdToName が GUID 文字列のままフォールバックする。
 var secureBootTemplateGUIDToName = map[string]string{
-	"1734C6E8-3154-4DDA-BA5F-A874CC483422": "MicrosoftWindows",
+	secureBootTemplateMicrosoftWindowsGUID: "MicrosoftWindows",
 }
 
 // secureBootTemplateIdToName は既知の GUID ならシンボリック名を、未知/空なら入力をそのまま返す。
@@ -29,11 +31,8 @@ func secureBootTemplateIdToName(guid string) string {
 }
 
 // firmwareFromSystemSettingData は Msvm_VirtualSystemSettingData から api.VmFirmware (スカラー部分) を
-// 組み立てる純関数。BootSourceOrder が非空 (Gen2 VM にブート可能デバイスが付いている場合、config で
-// boot_order を明示していなくても Hyper-V が自動生成する) の場合の扱いは呼び出し側 (GetVmFirmware) の
-// 責務とし、ここでは常に BootOrders=nil の api.VmFirmware を返す (silent drop ではなく、非空ケースを
-// 呼び出し側が PS 委譲で処理する前提。Fable レビュー指摘: デバイス付き Gen2 VM 全般の Read を壊す
-// 「広すぎる拒否」を避けるため、ここでの明示エラーは撤回した)。
+// 組み立てる純関数。BootOrders は常に nil を返す (呼び出し側の GetVmFirmware が
+// resolveBootOrdersForVM で別途解決し、成功すれば上書きする)。
 func firmwareFromSystemSettingData(vmName string, settings *hyperv.Msvm_VirtualSystemSettingData) api.VmFirmware {
 	enableSecureBoot := api.OnOffState_Off
 	if settings.SecureBoot {
@@ -87,6 +86,9 @@ func (c *ClientConfig) GetVmFirmware(ctx context.Context, vmName string) (api.Vm
 
 	bootOrders, err := c.resolveBootOrdersForVM(ctx, vmName, guid, settings.BootSourceOrder)
 	if err != nil {
+		// strict モードで PS フォールバックが発火した際に原因を追えるよう理由を残す
+		// (Fable レビュー指摘、#97)。
+		log.Printf("[DEBUG][hyperv-wsman] GetVmFirmware %q: BootSourceOrder 相関解決に失敗、PS へ委譲します: %v", vmName, err)
 		return c.ClientConfig.GetVmFirmware(ctx, vmName)
 	}
 	firmware.BootOrders = bootOrders

--- a/api/hyperv-wsman/vm_firmware_bootorder.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder.go
@@ -1,0 +1,114 @@
+package hyperv_wsman
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// resolveBootOrders は Msvm_VirtualSystemSettingData.BootSourceOrder[] を api.Gen2BootOrder の
+// 順序付きリストに変換する。
+//
+// 実機確認済み (2026-07-26、Gen2 シェル VM): Msvm_BootSourceSettingData.InstanceID は対象デバイス
+// (NIC の Msvm_SyntheticEthernetPortSettingData、または Drive の Msvm_ResourceAllocationSettingData)
+// の InstanceID に "\B" を付けたものと完全一致する (NIC: "Microsoft:<VM>\<PortGUID>\B"、Drive:
+// "Microsoft:<VM>\<CtrlGUID>\0\0\D\B")。BootSourceType (Network/Drive) で経路を分け、Drive の場合は
+// DVD/HardDisk のどちらかを driveInstanceID で突き合わせて種別を決める。
+//
+// 対応するデバイスが見つからない場合は silent drop せず明示エラーにする (DoD: 黙って成功報告する
+// 実装は禁止)。BootOrders が欠落したまま Terraform に「空」を返すと、次回 apply で意図しない
+// BootSourceOrder のクリアを招く危険がある。
+func resolveBootOrders(
+	bootSourceOrder []string,
+	bootSources []*hyperv.Msvm_BootSourceSettingData,
+	nicRefs []networkAdapterRef,
+	dvdRefs []dvdDriveRef,
+	diskRefs []hardDiskDriveRef,
+) ([]api.Gen2BootOrder, error) {
+	if len(bootSourceOrder) == 0 {
+		return nil, nil
+	}
+
+	bootSourceByID := make(map[string]*hyperv.Msvm_BootSourceSettingData, len(bootSources))
+	for _, bs := range bootSources {
+		bootSourceByID[bs.InstanceID] = bs
+	}
+
+	result := make([]api.Gen2BootOrder, 0, len(bootSourceOrder))
+	for _, ref := range bootSourceOrder {
+		bootOrder, err := resolveOneBootOrder(ref, bootSourceByID, nicRefs, dvdRefs, diskRefs)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, bootOrder)
+	}
+	return result, nil
+}
+
+// resolveOneBootOrder は BootSourceOrder[] の 1 エントリを解決する。
+func resolveOneBootOrder(
+	ref string,
+	bootSourceByID map[string]*hyperv.Msvm_BootSourceSettingData,
+	nicRefs []networkAdapterRef,
+	dvdRefs []dvdDriveRef,
+	diskRefs []hardDiskDriveRef,
+) (api.Gen2BootOrder, error) {
+	bootSourceID := extractInstanceIDFromRef(ref)
+	bs, ok := bootSourceByID[bootSourceID]
+	if !ok {
+		return api.Gen2BootOrder{}, fmt.Errorf(
+			"hyperv-wsman: BootSourceOrder のエントリ %q に対応する Msvm_BootSourceSettingData が見つかりません", bootSourceID)
+	}
+	deviceInstanceID := strings.TrimSuffix(bootSourceID, `\B`)
+
+	switch bs.BootSourceType {
+	case hyperv.BootSourceTypeNetwork:
+		for _, r := range nicRefs {
+			if r.portInstanceID != deviceInstanceID {
+				continue
+			}
+			macAddress := ""
+			if !r.adapter.DynamicMacAddress {
+				macAddress = r.adapter.StaticMacAddress
+			}
+			return api.Gen2BootOrder{
+				Type:               api.Gen2BootType_NetworkAdapter,
+				NetworkAdapterName: r.adapter.Name,
+				SwitchName:         r.adapter.SwitchName,
+				MacAddress:         macAddress,
+			}, nil
+		}
+		return api.Gen2BootOrder{}, fmt.Errorf(
+			"hyperv-wsman: BootSource %q (Network) に対応する NIC が見つかりません", deviceInstanceID)
+
+	case hyperv.BootSourceTypeDrive:
+		for _, r := range dvdRefs {
+			if r.driveInstanceID == deviceInstanceID {
+				return api.Gen2BootOrder{
+					Type:               api.Gen2BootType_DvdDrive,
+					Path:               r.dvd.Path,
+					ControllerNumber:   r.dvd.ControllerNumber,
+					ControllerLocation: r.dvd.ControllerLocation,
+				}, nil
+			}
+		}
+		for _, r := range diskRefs {
+			if r.driveInstanceID == deviceInstanceID {
+				return api.Gen2BootOrder{
+					Type:               api.Gen2BootType_HardDiskDrive,
+					Path:               r.drive.Path,
+					ControllerNumber:   int(r.drive.ControllerNumber),
+					ControllerLocation: int(r.drive.ControllerLocation),
+				}, nil
+			}
+		}
+		return api.Gen2BootOrder{}, fmt.Errorf(
+			"hyperv-wsman: BootSource %q (Drive) に対応する DVD/HardDisk が見つかりません", deviceInstanceID)
+
+	default:
+		return api.Gen2BootOrder{}, fmt.Errorf(
+			"hyperv-wsman: BootSource %q の BootSourceType %d は未対応です (File/Unknown)", bootSourceID, bs.BootSourceType)
+	}
+}

--- a/api/hyperv-wsman/vm_firmware_bootorder.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder.go
@@ -11,11 +11,20 @@ import (
 // resolveBootOrders は Msvm_VirtualSystemSettingData.BootSourceOrder[] を api.Gen2BootOrder の
 // 順序付きリストに変換する。
 //
-// 実機確認済み (2026-07-26、Gen2 シェル VM): Msvm_BootSourceSettingData.InstanceID は対象デバイス
-// (NIC の Msvm_SyntheticEthernetPortSettingData、または Drive の Msvm_ResourceAllocationSettingData)
-// の InstanceID に "\B" を付けたものと完全一致する (NIC: "Microsoft:<VM>\<PortGUID>\B"、Drive:
+// 実機確認済み (2026-07-26、Gen2 シェル VM、NIC 1台+SCSI Controller 1台+DVD 1台の1パターンのみ):
+// Msvm_BootSourceSettingData.InstanceID は対象デバイス (NIC の
+// Msvm_SyntheticEthernetPortSettingData、または Drive の Msvm_ResourceAllocationSettingData) の
+// InstanceID に "\B" を付けたものと完全一致する (NIC: "Microsoft:<VM>\<PortGUID>\B"、DVD 経由 SCSI:
 // "Microsoft:<VM>\<CtrlGUID>\0\0\D\B")。BootSourceType (Network/Drive) で経路を分け、Drive の場合は
-// DVD/HardDisk のどちらかを driveInstanceID で突き合わせて種別を決める。
+// DVD/HardDisk のどちらかを driveInstanceID (CIM 上ホスト内一意なキー) で突き合わせて種別を決める
+// (dvdRefs/diskRefs は ResourceSubType で構築時点から排他なので誤分類は構造上起きない)。
+// **HardDiskDrive (VHD ブート) の相関は実機未検証**(go-wsman コードの対称性からの類推のみ)。
+//
+// File 型 (Windows Boot Manager、OS インストール済み Gen2 VM が持つ) は本関数では未対応で、
+// resolveOneBootOrder が明示エラーを返し呼び出し側 (GetVmFirmware) が PS へ委譲する。つまり
+// **OS インストール済みの Gen2 VM の firmware read は現状ほぼ確実に PS 委譲になる**(未インストールの
+// 使い捨て VM 等、Network/Drive のみで構成される場合だけ go-wsman 側で完結する)。PS 版もこの
+// File 型エントリを暗黙 drop する実装のため、委譲先の最終結果自体は変わらない。
 //
 // 対応するデバイスが見つからない場合は silent drop せず明示エラーにする (DoD: 黙って成功報告する
 // 実装は禁止)。BootOrders が欠落したまま Terraform に「空」を返すと、次回 apply で意図しない

--- a/api/hyperv-wsman/vm_firmware_bootorder_test.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder_test.go
@@ -1,0 +1,119 @@
+package hyperv_wsman
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// テスト用の実機確認済み ID 形式 (2026-07-26、Gen2 シェル VM):
+//   NIC ブートソース   : Microsoft:<VMGUID>\<PortGUID>\B          → 実 NIC = Microsoft:<VMGUID>\<PortGUID>
+//   Drive ブートソース : Microsoft:<VMGUID>\<CtrlGUID>\0\0\D\B    → 実 Drive = Microsoft:<VMGUID>\<CtrlGUID>\0\0\D
+// つまり BootSource.InstanceID は対象デバイスの InstanceID に "\B" を付けたものと一致する。
+
+func TestResolveBootOrders(t *testing.T) {
+	const vm = "11111111-aaaa-bbbb-cccc-000000000001"
+	nicDeviceID := `Microsoft:` + vm + `\nic-guid`
+	dvdDeviceID := `Microsoft:` + vm + `\ctrl-guid\0\0\D`
+	diskDeviceID := `Microsoft:` + vm + `\ctrl-guid\0\1\D`
+
+	bootSourceOrder := []string{
+		`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="` + nicDeviceID + `\B"`,
+		`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="` + dvdDeviceID + `\B"`,
+		`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="` + diskDeviceID + `\B"`,
+	}
+	bootSources := []*hyperv.Msvm_BootSourceSettingData{
+		{InstanceID: nicDeviceID + `\B`, BootSourceType: hyperv.BootSourceTypeNetwork, BootSourceDescription: "EFI Network"},
+		{InstanceID: dvdDeviceID + `\B`, BootSourceType: hyperv.BootSourceTypeDrive, BootSourceDescription: "EFI SCSI Device"},
+		{InstanceID: diskDeviceID + `\B`, BootSourceType: hyperv.BootSourceTypeDrive, BootSourceDescription: "EFI SCSI Device"},
+	}
+	nicRefs := []networkAdapterRef{
+		{portInstanceID: nicDeviceID, adapter: api.VmNetworkAdapter{Name: "eth0", SwitchName: "Internet-sw", DynamicMacAddress: true}},
+	}
+	dvdRefs := []dvdDriveRef{
+		{driveInstanceID: dvdDeviceID, dvd: api.VmDvdDrive{ControllerNumber: 0, ControllerLocation: 0, Path: `H:\ISO\ubuntu.iso`}},
+	}
+	diskRefs := []hardDiskDriveRef{
+		{driveInstanceID: diskDeviceID, drive: api.VmHardDiskDrive{ControllerNumber: 0, ControllerLocation: 1, Path: `D:\VMs\disk.vhdx`}},
+	}
+
+	got, err := resolveBootOrders(bootSourceOrder, bootSources, nicRefs, dvdRefs, diskRefs)
+	if err != nil {
+		t.Fatalf("resolveBootOrders: %v", err)
+	}
+	want := []api.Gen2BootOrder{
+		{Type: api.Gen2BootType_NetworkAdapter, NetworkAdapterName: "eth0", SwitchName: "Internet-sw"},
+		{Type: api.Gen2BootType_DvdDrive, ControllerNumber: 0, ControllerLocation: 0, Path: `H:\ISO\ubuntu.iso`},
+		{Type: api.Gen2BootType_HardDiskDrive, ControllerNumber: 0, ControllerLocation: 1, Path: `D:\VMs\disk.vhdx`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("resolveBootOrders:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+// TestResolveBootOrders_StaticMac は静的 MAC の NIC がブートソースの場合、MacAddress が
+// 引き継がれることを検証する。
+func TestResolveBootOrders_StaticMac(t *testing.T) {
+	const vm = "11111111-aaaa-bbbb-cccc-000000000001"
+	nicDeviceID := `Microsoft:` + vm + `\nic-guid`
+	bootSourceOrder := []string{
+		`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="` + nicDeviceID + `\B"`,
+	}
+	bootSources := []*hyperv.Msvm_BootSourceSettingData{
+		{InstanceID: nicDeviceID + `\B`, BootSourceType: hyperv.BootSourceTypeNetwork},
+	}
+	nicRefs := []networkAdapterRef{
+		{portInstanceID: nicDeviceID, adapter: api.VmNetworkAdapter{Name: "eth0", DynamicMacAddress: false, StaticMacAddress: "001122334455"}},
+	}
+
+	got, err := resolveBootOrders(bootSourceOrder, bootSources, nicRefs, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveBootOrders: %v", err)
+	}
+	if len(got) != 1 || got[0].MacAddress != "001122334455" {
+		t.Errorf("got: %+v", got)
+	}
+}
+
+// TestResolveBootOrders_UnresolvedDevice は BootSource が実デバイス一覧に見つからない場合、
+// silent drop せず明示エラーになることを検証する (DoD: 黙って成功報告する実装は禁止)。
+func TestResolveBootOrders_UnresolvedDevice(t *testing.T) {
+	const vm = "11111111-aaaa-bbbb-cccc-000000000001"
+	nicDeviceID := `Microsoft:` + vm + `\nic-guid-missing`
+	bootSourceOrder := []string{
+		`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="` + nicDeviceID + `\B"`,
+	}
+	bootSources := []*hyperv.Msvm_BootSourceSettingData{
+		{InstanceID: nicDeviceID + `\B`, BootSourceType: hyperv.BootSourceTypeNetwork},
+	}
+	// nicRefs が空 → 対応する NIC が見つからない。
+	_, err := resolveBootOrders(bootSourceOrder, bootSources, nil, nil, nil)
+	if err == nil {
+		t.Fatal("対応デバイスが見つからない場合は明示エラーになるべき")
+	}
+}
+
+// TestResolveBootOrders_UnresolvedBootSource は BootSourceOrder のエントリに対応する
+// Msvm_BootSourceSettingData 自体が見つからない場合、明示エラーになることを検証する。
+func TestResolveBootOrders_UnresolvedBootSource(t *testing.T) {
+	bootSourceOrder := []string{
+		`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="Microsoft:vm\missing\B"`,
+	}
+	_, err := resolveBootOrders(bootSourceOrder, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("対応する BootSourceSettingData が無い場合は明示エラーになるべき")
+	}
+}
+
+// TestResolveBootOrders_Empty は空リストで no-op (nil, no error) を返すことを検証する。
+func TestResolveBootOrders_Empty(t *testing.T) {
+	got, err := resolveBootOrders(nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveBootOrders: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got: %+v", got)
+	}
+}

--- a/api/hyperv-wsman/vm_firmware_bootorder_test.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder_test.go
@@ -107,6 +107,25 @@ func TestResolveBootOrders_UnresolvedBootSource(t *testing.T) {
 	}
 }
 
+// TestResolveBootOrders_FileTypeUnsupported は BootSourceType=File (Windows Boot Manager、OS
+// インストール済み VM が持つ) の場合に silent drop せず明示エラーになることを検証する。実運用では
+// このエラーを受けて GetVmFirmware が PS へ委譲する (OS インストール済み VM の firmware read は
+// ほぼ確実に PS 委譲になる制約、vm_firmware_bootorder.go の doc コメント参照)。
+func TestResolveBootOrders_FileTypeUnsupported(t *testing.T) {
+	const vm = "11111111-aaaa-bbbb-cccc-000000000001"
+	fileDeviceID := `Microsoft:` + vm + `\boot-mgr-guid`
+	bootSourceOrder := []string{
+		`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="` + fileDeviceID + `\B"`,
+	}
+	bootSources := []*hyperv.Msvm_BootSourceSettingData{
+		{InstanceID: fileDeviceID + `\B`, BootSourceType: hyperv.BootSourceTypeFile, BootSourceDescription: "Windows Boot Manager"},
+	}
+	_, err := resolveBootOrders(bootSourceOrder, bootSources, nil, nil, nil)
+	if err == nil {
+		t.Fatal("BootSourceType=File は未対応のため明示エラーになるべき")
+	}
+}
+
 // TestResolveBootOrders_Empty は空リストで no-op (nil, no error) を返すことを検証する。
 func TestResolveBootOrders_Empty(t *testing.T) {
 	got, err := resolveBootOrders(nil, nil, nil, nil, nil)

--- a/api/hyperv-wsman/vm_firmware_test.go
+++ b/api/hyperv-wsman/vm_firmware_test.go
@@ -31,7 +31,7 @@ func TestSecureBootTemplateIdToName(t *testing.T) {
 		id   string
 		want string
 	}{
-		{"MicrosoftWindows (実機確認済み)", "1734C6E8-3154-4DDA-BA5F-A874CC483422", "MicrosoftWindows"},
+		{"MicrosoftWindows (実機確認済み)", secureBootTemplateMicrosoftWindowsGUID, "MicrosoftWindows"},
 		{"未知のGUIDはそのまま返す", "00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000"},
 		{"空文字はそのまま返す", "", ""},
 	}
@@ -47,7 +47,7 @@ func TestSecureBootTemplateIdToName(t *testing.T) {
 func TestFirmwareFromSystemSettingData(t *testing.T) {
 	settings := &hyperv.Msvm_VirtualSystemSettingData{
 		SecureBoot:                   true,
-		SecureBootTemplateId:         "1734C6E8-3154-4DDA-BA5F-A874CC483422",
+		SecureBootTemplateId:         secureBootTemplateMicrosoftWindowsGUID,
 		NetworkBootPreferredProtocol: hyperv.NetworkBootPreferredProtocolIPv6,
 		ConsoleMode:                  hyperv.ConsoleModeCOM1,
 		PauseAfterBootFailure:        true,

--- a/api/hyperv-wsman/vm_firmware_test.go
+++ b/api/hyperv-wsman/vm_firmware_test.go
@@ -93,15 +93,11 @@ func TestFirmwareFromSystemSettingData_Defaults(t *testing.T) {
 	}
 }
 
-// TestGetVmFirmware_DelegatesWhenBootSourceOrderNonEmpty は BootSourceOrder が非空 (ブート可能
-// デバイスが付いている Gen2 VM) の場合に、silent drop や広すぎる拒否をせず埋め込み PS (winrm) 実装へ
-// 委譲することを検証する (Fable レビュー指摘、#96)。委譲分岐では nil 埋め込みクライアントの参照で
-// panic することを利用し、「BootOrders を無視して空扱いにする」のではなく確実に委譲したことを確認する
-// (WaitForVmNetworkAdaptersIps と同じ確認手法)。
-//
-// GetSystemSettingData 自体は httptest サーバで実際に応答させ (WsmanClient は本物の *hyperv.Client)、
-// BootSourceOrder が非空の Msvm_VirtualSystemSettingData を返す。
-func TestGetVmFirmware_DelegatesWhenBootSourceOrderNonEmpty(t *testing.T) {
+// TestGetVmFirmware_DelegatesWhenBootOrderResolutionFails は BootSourceOrder 相関解決が失敗する
+// 場合 (このテストでは ListBootSources 自体をエラーにして強制する) に、silent drop も広すぎる拒否も
+// せず埋め込み PS (winrm) 実装へ委譲することを検証する。委譲分岐では nil 埋め込みクライアントの参照で
+// panic することを利用し、確実に委譲したことを確認する (WaitForVmNetworkAdaptersIps と同じ確認手法)。
+func TestGetVmFirmware_DelegatesWhenBootOrderResolutionFails(t *testing.T) {
 	const vmName = "vm-1"
 	const vmGUID = "11111111-aaaa-bbbb-cccc-000000000001"
 	const enumXML = `<?xml version="1.0" encoding="UTF-8"?>
@@ -136,6 +132,12 @@ func TestGetVmFirmware_DelegatesWhenBootSourceOrderNonEmpty(t *testing.T) {
 	responses := []string{enumXML, computerSystemPullXML, enumXML, settingDataPullXML}
 	callCount := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if callCount >= len(responses) {
+			// resolveVMGUID + GetSystemSettingData 分 (4 リクエスト) 以降、ListBootSources の
+			// Enumerate をエラーにして相関解決を強制的に失敗させ、PS 委譲分岐を確実に踏ませる。
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "application/soap+xml; charset=utf-8")
 		_, _ = w.Write([]byte(responses[callCount]))
 		callCount++

--- a/internal/provider/firmware_read_integration_test.go
+++ b/internal/provider/firmware_read_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/r4sd/go-wsman/hyperv"
 	"github.com/taliesins/terraform-provider-hyperv/api"
 	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
 )
@@ -88,4 +89,110 @@ func TestRealHostFirmwareReadWsman(t *testing.T) {
 		t.Fatalf("GetVmFirmwares: got %d件, want 1", len(firmwares))
 	}
 	t.Logf("✅ GetVmFirmwares (1件ラップ) も確認")
+}
+
+// TestRealHostFirmwareBootOrderWsman は BootSourceOrder→Gen2BootOrder の相関ロジックを実機で検証する。
+// NIC + SCSI Controller + DVD (Ubuntu ISO) を付けた Gen2 VM で GetVmFirmware を呼び、
+// BootOrders に NetworkAdapter と DvdDrive が正しく解決されることを確認する。
+func TestRealHostFirmwareBootOrderWsman(t *testing.T) {
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+	cc := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	ctx := context.Background()
+
+	const vmName = "tf-wsman-firmware-bootorder-test"
+	_ = cc.DeleteVm(ctx, vmName)
+	t.Cleanup(func() {
+		if err := cc.DeleteVm(ctx, vmName); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+
+	const memByt = 536870912
+	if err := cc.CreateVm(ctx, vmName,
+		"", 2, // Generation 2
+		api.CriticalErrorAction_Pause, 0,
+		api.StartAction_Nothing, 0,
+		api.StopAction_Save,
+		api.CheckpointType_Production,
+		false, false, 0,
+		api.OnOffState_Off, 0,
+		memByt, memByt, memByt,
+		"firmware-bootorder-test", 1,
+		"", "", true, false,
+	); err != nil {
+		t.Fatalf("CreateVm: %v", err)
+	}
+
+	vm, err := wsmanClient.FindComputerSystemByElementName(ctx, vmName)
+	if err != nil {
+		t.Fatalf("FindComputerSystemByElementName: %v", err)
+	}
+	vmGUID := vm.Name
+
+	// NIC (スイッチ接続なし、go-wsman #114 の影響を避ける)。
+	nicRes, err := wsmanClient.AddNetworkAdapter(ctx, vmGUID, hyperv.NetworkAdapterOptions{ElementName: "eth0-boottest"})
+	if err != nil {
+		t.Fatalf("AddNetworkAdapter: %v", err)
+	}
+	if nicRes.JobRef != "" {
+		if err := wsmanClient.WaitForJob(ctx, nicRes.JobRef); err != nil {
+			t.Fatalf("WaitForJob(AddNetworkAdapter): %v", err)
+		}
+	}
+
+	scsiRes, err := wsmanClient.AddScsiController(ctx, vmGUID)
+	if err != nil {
+		t.Fatalf("AddScsiController: %v", err)
+	}
+	if scsiRes.JobRef != "" {
+		if err := wsmanClient.WaitForJob(ctx, scsiRes.JobRef); err != nil {
+			t.Fatalf("WaitForJob(AddScsiController): %v", err)
+		}
+	}
+
+	const isoPath = `H:\ISO\ubuntu-24.04.4-live-server-amd64.iso`
+	dvdRes, err := wsmanClient.AttachDVD(ctx, vmGUID, hyperv.AttachDVDOptions{
+		ControllerType: hyperv.ControllerTypeSCSI, ControllerNumber: 0, ControllerLocation: 0, Path: isoPath,
+	})
+	if err != nil {
+		t.Fatalf("AttachDVD: %v", err)
+	}
+	if dvdRes.JobRef != "" {
+		if err := wsmanClient.WaitForJob(ctx, dvdRes.JobRef); err != nil {
+			t.Fatalf("WaitForJob(AttachDVD): %v", err)
+		}
+	}
+
+	firmware, err := cc.GetVmFirmware(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmFirmware: %v", err)
+	}
+	t.Logf("firmware.BootOrders: %+v", firmware.BootOrders)
+
+	if len(firmware.BootOrders) != 2 {
+		t.Fatalf("BootOrders件数: got %d, want 2 (NIC+DVD)。相関解決に失敗し PS 委譲が発生した可能性あり", len(firmware.BootOrders))
+	}
+	var haveNIC, haveDVD bool
+	for _, b := range firmware.BootOrders {
+		switch b.Type {
+		case api.Gen2BootType_NetworkAdapter:
+			haveNIC = true
+			if b.NetworkAdapterName != "eth0-boottest" {
+				t.Errorf("NetworkAdapterName: got %q, want \"eth0-boottest\"", b.NetworkAdapterName)
+			}
+		case api.Gen2BootType_DvdDrive:
+			haveDVD = true
+			if b.Path != isoPath {
+				t.Errorf("DvdDrive Path: got %q, want %q", b.Path, isoPath)
+			}
+		}
+	}
+	if !haveNIC || !haveDVD {
+		t.Errorf("NIC/DVD 両方の BootOrder が解決されるべき: haveNIC=%v haveDVD=%v", haveNIC, haveDVD)
+	}
+	t.Logf("✅ BootSourceOrder→Gen2BootOrder 相関解決を実機で確認")
 }


### PR DESCRIPTION
## Summary
- PR #96 でスコープ外にした BootOrders (ブート順序) の go-wsman 化を完成
- 実機確認済みの対応関係 (BootSource.InstanceID = デバイスの InstanceID + "\B") で NIC/DVD/HardDisk を解決
- 解決できない場合は PS へ委譲 (silent drop 回避)

## Test plan
- [x] unit test (純関数、境界ケース含む)
- [x] 実機 acc test (`TestRealHostFirmwareBootOrderWsman`)、NIC+SCSI+DVD 付き Gen2 VM で NetworkAdapter/DvdDrive 両方の解決を確認
- [x] `go build` / `go vet` / `go test ./...` green