### PR TITLE
feat: vm_firmware の書き込みを go-wsman 化 + フルライフサイクル PS-0 実機テスト (Slice D WRITE + Slice E, #80)

### DIFF
--- a/api/hyperv-wsman/vm_firmware.go
+++ b/api/hyperv-wsman/vm_firmware.go
@@ -30,6 +30,25 @@ func secureBootTemplateIdToName(guid string) string {
 	return guid
 }
 
+// secureBootTemplateNameToGUID は secureBootTemplateIdToName の逆変換 (書き込み用)。
+// 空文字は「テンプレート未指定」として ""/true (delegate 判定に使う zero 値扱い)。既に GUID 形式の
+// 入力 (state からの再入力等) もそのまま通す。未知のシンボル名は ok=false を返し、呼び出し側が
+// PS 委譲を判断する材料にする (どの GUID を書けばよいか分からないため、当て推量で GUID を発行しない)。
+func secureBootTemplateNameToGUID(name string) (guid string, ok bool) {
+	if name == "" {
+		return "", true
+	}
+	if name == secureBootTemplateMicrosoftWindowsGUID {
+		return name, true
+	}
+	for g, n := range secureBootTemplateGUIDToName {
+		if n == name {
+			return g, true
+		}
+	}
+	return "", false
+}
+
 // firmwareFromSystemSettingData は Msvm_VirtualSystemSettingData から api.VmFirmware (スカラー部分) を
 // 組み立てる純関数。BootOrders は常に nil を返す (呼び出し側の GetVmFirmware が
 // resolveBootOrdersForVM で別途解決し、成功すれば上書きする)。

--- a/api/hyperv-wsman/vm_firmware.go
+++ b/api/hyperv-wsman/vm_firmware.go
@@ -31,9 +31,12 @@ func secureBootTemplateIdToName(guid string) string {
 }
 
 // secureBootTemplateNameToGUID は secureBootTemplateIdToName の逆変換 (書き込み用)。
-// 空文字は「テンプレート未指定」として ""/true (delegate 判定に使う zero 値扱い)。既に GUID 形式の
-// 入力 (state からの再入力等) もそのまま通す。未知のシンボル名は ok=false を返し、呼び出し側が
-// PS 委譲を判断する材料にする (どの GUID を書けばよいか分からないため、当て推量で GUID を発行しない)。
+// 空文字は「テンプレート未指定」として ""/true (zero 値、firmwareZeroDowngrade が現行値との比較で
+// 判断する)。既知の GUID (secureBootTemplateMicrosoftWindowsGUID) そのものが入力された場合もそのまま
+// 通す (state からの再入力等)。それ以外の未知のシンボル名・未知の GUID は ok=false を返し、
+// 呼び出し側が PS 委譲を判断する材料にする (どの GUID を書けばよいか分からないため、当て推量で
+// GUID を発行しない。MicrosoftUEFICertificateAuthority 等の他テンプレートは未確認のため #99 で
+// 追跡)。
 func secureBootTemplateNameToGUID(name string) (guid string, ok bool) {
 	if name == "" {
 		return "", true

--- a/api/hyperv-wsman/vm_firmware_bootorder.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder.go
@@ -162,13 +162,42 @@ func resolveBootOrderDeviceID(
 ) (string, error) {
 	switch bo.Type {
 	case api.Gen2BootType_NetworkAdapter:
+		// PS 版 (Get/Set-VMFirmware テンプレート) と同じく Name→SwitchName→MacAddress の順で絞り込む
+		// (指定されたものだけをフィルタ条件にする)。Hyper-V の NIC 既定名は "Network Adapter" で
+		// 同名 NIC が複数存在しうるため、Name だけの一致で決め打つと違う NIC を誤って書き込む危険が
+		// ある (Fable 指摘、silent corruption)。一意に絞り込めない場合は明示エラーにして PS へ
+		// 委譲する (DoD: 黙って成功報告する実装は禁止)。
+		var matches []networkAdapterRef
 		for _, r := range nicRefs {
-			if r.adapter.Name == bo.NetworkAdapterName {
-				return r.portInstanceID, nil
+			if r.adapter.Name != bo.NetworkAdapterName {
+				continue
 			}
+			if bo.SwitchName != "" && r.adapter.SwitchName != bo.SwitchName {
+				continue
+			}
+			if bo.MacAddress != "" {
+				mac := ""
+				if !r.adapter.DynamicMacAddress {
+					mac = r.adapter.StaticMacAddress
+				}
+				if !strings.EqualFold(mac, bo.MacAddress) {
+					continue
+				}
+			}
+			matches = append(matches, r)
 		}
-		return "", fmt.Errorf(
-			"hyperv-wsman: boot order の NetworkAdapter %q に対応する NIC が見つかりません", bo.NetworkAdapterName)
+		switch len(matches) {
+		case 1:
+			return matches[0].portInstanceID, nil
+		case 0:
+			return "", fmt.Errorf(
+				"hyperv-wsman: boot order の NetworkAdapter %q (SwitchName=%q MacAddress=%q) に対応する NIC が見つかりません",
+				bo.NetworkAdapterName, bo.SwitchName, bo.MacAddress)
+		default:
+			return "", fmt.Errorf(
+				"hyperv-wsman: boot order の NetworkAdapter %q が複数 (%d件) の NIC に一致し一意に特定できません。SwitchName/MacAddress で絞り込んでください",
+				bo.NetworkAdapterName, len(matches))
+		}
 
 	case api.Gen2BootType_DvdDrive:
 		for _, r := range dvdRefs {

--- a/api/hyperv-wsman/vm_firmware_bootorder.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder.go
@@ -121,3 +121,76 @@ func resolveOneBootOrder(
 			"hyperv-wsman: BootSource %q の BootSourceType %d は未対応です (File/Unknown)", bootSourceID, bs.BootSourceType)
 	}
 }
+
+// resolveBootSourceRefs は resolveBootOrders の逆変換で、api.Gen2BootOrder[] (書き込み要求) を
+// Msvm_VirtualSystemSettingData.BootSourceOrder[] に書く WMI 参照文字列のリストに変換する。
+// bootSourceRef は deviceInstanceID から参照文字列を組み立てる関数 (実体は
+// hyperv.Client.BootSourceRef、テストでは差し替え可能にするため関数値で受ける)。
+//
+// NetworkAdapter は NetworkAdapterName で、DvdDrive/HardDiskDrive は
+// ControllerNumber+ControllerLocation で対応デバイスを突き合わせる (resolveOneBootOrder の
+// 読み取り側と対称)。対応するデバイスが見つからない場合は silent drop せず明示エラーにする
+// (DoD: 黙って成功報告する実装は禁止)。
+func resolveBootSourceRefs(
+	bootSourceRef func(deviceInstanceID string) string,
+	bootOrders []api.Gen2BootOrder,
+	nicRefs []networkAdapterRef,
+	dvdRefs []dvdDriveRef,
+	diskRefs []hardDiskDriveRef,
+) ([]string, error) {
+	if len(bootOrders) == 0 {
+		return nil, nil
+	}
+
+	result := make([]string, 0, len(bootOrders))
+	for _, bo := range bootOrders {
+		deviceID, err := resolveBootOrderDeviceID(bo, nicRefs, dvdRefs, diskRefs)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, bootSourceRef(deviceID))
+	}
+	return result, nil
+}
+
+// resolveBootOrderDeviceID は 1 件の api.Gen2BootOrder に対応するデバイスの InstanceID を返す。
+func resolveBootOrderDeviceID(
+	bo api.Gen2BootOrder,
+	nicRefs []networkAdapterRef,
+	dvdRefs []dvdDriveRef,
+	diskRefs []hardDiskDriveRef,
+) (string, error) {
+	switch bo.Type {
+	case api.Gen2BootType_NetworkAdapter:
+		for _, r := range nicRefs {
+			if r.adapter.Name == bo.NetworkAdapterName {
+				return r.portInstanceID, nil
+			}
+		}
+		return "", fmt.Errorf(
+			"hyperv-wsman: boot order の NetworkAdapter %q に対応する NIC が見つかりません", bo.NetworkAdapterName)
+
+	case api.Gen2BootType_DvdDrive:
+		for _, r := range dvdRefs {
+			if r.dvd.ControllerNumber == bo.ControllerNumber && r.dvd.ControllerLocation == bo.ControllerLocation {
+				return r.driveInstanceID, nil
+			}
+		}
+		return "", fmt.Errorf(
+			"hyperv-wsman: boot order の DvdDrive (controller=%d location=%d) に対応するデバイスが見つかりません",
+			bo.ControllerNumber, bo.ControllerLocation)
+
+	case api.Gen2BootType_HardDiskDrive:
+		for _, r := range diskRefs {
+			if int(r.drive.ControllerNumber) == bo.ControllerNumber && int(r.drive.ControllerLocation) == bo.ControllerLocation {
+				return r.driveInstanceID, nil
+			}
+		}
+		return "", fmt.Errorf(
+			"hyperv-wsman: boot order の HardDiskDrive (controller=%d location=%d) に対応するデバイスが見つかりません",
+			bo.ControllerNumber, bo.ControllerLocation)
+
+	default:
+		return "", fmt.Errorf("hyperv-wsman: boot order の Type %v は未対応です", bo.Type)
+	}
+}

--- a/api/hyperv-wsman/vm_firmware_bootorder_test.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder_test.go
@@ -136,3 +136,78 @@ func TestResolveBootOrders_Empty(t *testing.T) {
 		t.Errorf("got: %+v", got)
 	}
 }
+
+// resolveBootSourceRefs (write 方向、resolveBootOrders の逆変換) のテスト。
+// bootSourceRefFunc は BootSourceRef(deviceInstanceID) の呼び出しをテスト内で検証可能にするための
+// 関数値 (go-wsman.Client を丸ごとモックする必要を避ける)。
+
+func TestResolveBootSourceRefs(t *testing.T) {
+	const vm = "11111111-aaaa-bbbb-cccc-000000000001"
+	nicDeviceID := `Microsoft:` + vm + `\nic-guid`
+	dvdDeviceID := `Microsoft:` + vm + `\ctrl-guid\0\0\D`
+	diskDeviceID := `Microsoft:` + vm + `\ctrl-guid\0\1\D`
+
+	nicRefs := []networkAdapterRef{
+		{portInstanceID: nicDeviceID, adapter: api.VmNetworkAdapter{Name: "eth0", SwitchName: "Internet-sw"}},
+	}
+	dvdRefs := []dvdDriveRef{
+		{driveInstanceID: dvdDeviceID, dvd: api.VmDvdDrive{ControllerNumber: 0, ControllerLocation: 0}},
+	}
+	diskRefs := []hardDiskDriveRef{
+		{driveInstanceID: diskDeviceID, drive: api.VmHardDiskDrive{ControllerNumber: 0, ControllerLocation: 1}},
+	}
+
+	bootOrders := []api.Gen2BootOrder{
+		{Type: api.Gen2BootType_NetworkAdapter, NetworkAdapterName: "eth0"},
+		{Type: api.Gen2BootType_DvdDrive, ControllerNumber: 0, ControllerLocation: 0},
+		{Type: api.Gen2BootType_HardDiskDrive, ControllerNumber: 0, ControllerLocation: 1},
+	}
+
+	fakeBootSourceRef := func(deviceInstanceID string) string {
+		return "REF:" + deviceInstanceID
+	}
+
+	got, err := resolveBootSourceRefs(fakeBootSourceRef, bootOrders, nicRefs, dvdRefs, diskRefs)
+	if err != nil {
+		t.Fatalf("resolveBootSourceRefs: %v", err)
+	}
+	want := []string{"REF:" + nicDeviceID, "REF:" + dvdDeviceID, "REF:" + diskDeviceID}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("resolveBootSourceRefs:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+// TestResolveBootSourceRefs_UnresolvedNetworkAdapter は名前の一致する NIC が無い場合、
+// silent drop せず明示エラーになることを検証する。
+func TestResolveBootSourceRefs_UnresolvedNetworkAdapter(t *testing.T) {
+	bootOrders := []api.Gen2BootOrder{
+		{Type: api.Gen2BootType_NetworkAdapter, NetworkAdapterName: "missing"},
+	}
+	_, err := resolveBootSourceRefs(func(string) string { return "" }, bootOrders, nil, nil, nil)
+	if err == nil {
+		t.Fatal("対応する NIC が無い場合は明示エラーになるべき")
+	}
+}
+
+// TestResolveBootSourceRefs_UnresolvedDrive は controller/location の一致する DVD/HardDisk が
+// 無い場合、明示エラーになることを検証する。
+func TestResolveBootSourceRefs_UnresolvedDrive(t *testing.T) {
+	bootOrders := []api.Gen2BootOrder{
+		{Type: api.Gen2BootType_DvdDrive, ControllerNumber: 9, ControllerLocation: 9},
+	}
+	_, err := resolveBootSourceRefs(func(string) string { return "" }, bootOrders, nil, nil, nil)
+	if err == nil {
+		t.Fatal("対応する Drive が無い場合は明示エラーになるべき")
+	}
+}
+
+// TestResolveBootSourceRefs_Empty は空リストで no-op (nil, no error) を返すことを検証する。
+func TestResolveBootSourceRefs_Empty(t *testing.T) {
+	got, err := resolveBootSourceRefs(func(string) string { return "" }, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveBootSourceRefs: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got: %+v", got)
+	}
+}

--- a/api/hyperv-wsman/vm_firmware_bootorder_test.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder_test.go
@@ -211,3 +211,40 @@ func TestResolveBootSourceRefs_Empty(t *testing.T) {
 		t.Errorf("got: %+v", got)
 	}
 }
+
+// TestResolveBootSourceRefs_AmbiguousNetworkAdapterName は同名 NIC が複数存在する場合
+// (Hyper-V の既定名 "Network Adapter" 等)、Name のみの一致で決め打たず明示エラーになることを
+// 検証する。Name だけで先頭一致させると違う NIC の InstanceID を誤って書き込む危険がある
+// (Fable 敵対レビュー指摘、silent corruption)。
+func TestResolveBootSourceRefs_AmbiguousNetworkAdapterName(t *testing.T) {
+	nicRefs := []networkAdapterRef{
+		{portInstanceID: "nic-1", adapter: api.VmNetworkAdapter{Name: "Network Adapter", SwitchName: "Internet-sw"}},
+		{portInstanceID: "nic-2", adapter: api.VmNetworkAdapter{Name: "Network Adapter", SwitchName: "internal-sw"}},
+	}
+	bootOrders := []api.Gen2BootOrder{
+		{Type: api.Gen2BootType_NetworkAdapter, NetworkAdapterName: "Network Adapter"},
+	}
+	_, err := resolveBootSourceRefs(func(string) string { return "" }, bootOrders, nicRefs, nil, nil)
+	if err == nil {
+		t.Fatal("Name だけで複数 NIC に一致する場合は明示エラーになるべき (silent corruption 回避)")
+	}
+}
+
+// TestResolveBootSourceRefs_DisambiguateBySwitchName は同名 NIC でも SwitchName を指定すれば
+// 一意に解決できることを検証する (PS 版 Set-VMFirmware テンプレートと同じ絞り込み)。
+func TestResolveBootSourceRefs_DisambiguateBySwitchName(t *testing.T) {
+	nicRefs := []networkAdapterRef{
+		{portInstanceID: "nic-1", adapter: api.VmNetworkAdapter{Name: "Network Adapter", SwitchName: "Internet-sw"}},
+		{portInstanceID: "nic-2", adapter: api.VmNetworkAdapter{Name: "Network Adapter", SwitchName: "internal-sw"}},
+	}
+	bootOrders := []api.Gen2BootOrder{
+		{Type: api.Gen2BootType_NetworkAdapter, NetworkAdapterName: "Network Adapter", SwitchName: "internal-sw"},
+	}
+	got, err := resolveBootSourceRefs(func(id string) string { return "REF:" + id }, bootOrders, nicRefs, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveBootSourceRefs: %v", err)
+	}
+	if len(got) != 1 || got[0] != "REF:nic-2" {
+		t.Errorf("got: %+v, want REF:nic-2 (internal-sw の NIC)", got)
+	}
+}

--- a/api/hyperv-wsman/vm_firmware_test.go
+++ b/api/hyperv-wsman/vm_firmware_test.go
@@ -13,16 +13,18 @@ import (
 )
 
 // TestClientConfig_ImplementsHypervVmFirmwareClient は ClientConfig が
-// api.HypervVmFirmwareClient を実装し、無条件 PS だった GetVmFirmware/GetVmFirmwares が
-// 本パッケージでシャドウイング (promotion ではなく直接定義) されていることを検証する。
-// CreateOrUpdate/GetNoVmFirmwares は埋め込み winrm から promotion されるため、ここでは検証しない
-// (WRITE 側は Slice D 継続)。
+// api.HypervVmFirmwareClient を実装し、無条件 PS だった GetVmFirmware/GetVmFirmwares/
+// CreateOrUpdateVmFirmware/CreateOrUpdateVmFirmwares が本パッケージでシャドウイング
+// (promotion ではなく直接定義) されていることを検証する。GetNoVmFirmwares は埋め込み winrm から
+// promotion される (PS 版と同じ「未対応」契約のため shadow しない)。
 func TestClientConfig_ImplementsHypervVmFirmwareClient(t *testing.T) {
 	var c *ClientConfig
 	var _ api.HypervVmFirmwareClient = c // コンパイル時チェック
 
 	assertShadowedIn(t, "GetVmFirmware", "vm_firmware.go")
 	assertShadowedIn(t, "GetVmFirmwares", "vm_firmware.go")
+	assertShadowedIn(t, "CreateOrUpdateVmFirmware", "vm_firmware_write.go")
+	assertShadowedIn(t, "CreateOrUpdateVmFirmwares", "vm_firmware_write.go")
 }
 
 func TestSecureBootTemplateIdToName(t *testing.T) {
@@ -39,6 +41,28 @@ func TestSecureBootTemplateIdToName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := secureBootTemplateIdToName(tt.id); got != tt.want {
 				t.Errorf("secureBootTemplateIdToName(%q): got %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecureBootTemplateNameToGUID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantGUID string
+		wantOK   bool
+	}{
+		{"空文字は変更なし扱い", "", "", true},
+		{"既知のシンボル名", "MicrosoftWindows", secureBootTemplateMicrosoftWindowsGUID, true},
+		{"GUID形式の入力もそのまま通す", secureBootTemplateMicrosoftWindowsGUID, secureBootTemplateMicrosoftWindowsGUID, true},
+		{"未知のシンボル名はok=false", "SomeUnknownTemplate", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotGUID, gotOK := secureBootTemplateNameToGUID(tt.input)
+			if gotGUID != tt.wantGUID || gotOK != tt.wantOK {
+				t.Errorf("secureBootTemplateNameToGUID(%q): got (%q, %v), want (%q, %v)", tt.input, gotGUID, gotOK, tt.wantGUID, tt.wantOK)
 			}
 		})
 	}

--- a/api/hyperv-wsman/vm_firmware_write.go
+++ b/api/hyperv-wsman/vm_firmware_write.go
@@ -47,13 +47,32 @@ func buildFirmwareCIMValues(
 
 // firmwareWriteNoop は current (現行 CIM 値) と want (書き込み要求値) が完全一致するかを返す。
 // 一致する場合は Set を省略できる (差分なしガード、homelab 既定運用の strict PS-0 維持)。
+//
+// BootSourceOrder は current (サーバが返す生の WMI 参照文字列、ホスト前置+バックスラッシュ区切りの
+// 実機形式) と want (BootSourceRef が組み立てるクライアント側参照文字列、wmiObjectPath はホスト
+// 前置なし+フォワードスラッシュ区切りの namespace) とで文字列表現が一致しない (Fable 指摘)。
+// 生文字列比較では常に不一致になり差分なしガードが機能しないため、両辺を
+// extractInstanceIDFromRef で素の InstanceID に正規化してから比較する。
 func firmwareWriteNoop(current *hyperv.Msvm_VirtualSystemSettingData, want firmwareCIMValues) bool {
 	return current.SecureBoot == want.secureBoot &&
 		current.SecureBootTemplateId == want.secureBootTemplateGUID &&
 		current.NetworkBootPreferredProtocol == want.networkBootProtocol &&
 		current.ConsoleMode == want.consoleMode &&
 		current.PauseAfterBootFailure == want.pauseAfterBootFailure &&
-		stringSlicesEqual(current.BootSourceOrder, want.bootSourceOrder)
+		stringSlicesEqual(normalizedBootSourceOrder(current.BootSourceOrder), normalizedBootSourceOrder(want.bootSourceOrder))
+}
+
+// normalizedBootSourceOrder は BootSourceOrder[] の各要素を素の InstanceID に正規化する
+// (extractInstanceIDFromRef、firmwareWriteNoop の比較専用)。
+func normalizedBootSourceOrder(refs []string) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]string, len(refs))
+	for i, ref := range refs {
+		out[i] = extractInstanceIDFromRef(ref)
+	}
+	return out
 }
 
 // firmwareZeroDowngrade は current → want が「非ゼロ→ゼロ」の遷移を含むかを返す。

--- a/api/hyperv-wsman/vm_firmware_write.go
+++ b/api/hyperv-wsman/vm_firmware_write.go
@@ -1,0 +1,202 @@
+package hyperv_wsman
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+// firmwareCIMValues は CreateOrUpdateVmFirmware の要求パラメータを CIM (Msvm_VirtualSystemSettingData)
+// の形に変換した値。判定・適用ロジックをネットワーク呼び出しから切り離してテスト可能にするための型。
+type firmwareCIMValues struct {
+	secureBoot             bool
+	secureBootTemplateGUID string
+	networkBootProtocol    uint16
+	consoleMode            uint16
+	pauseAfterBootFailure  bool
+	bootSourceOrder        []string
+}
+
+// buildFirmwareCIMValues は CreateOrUpdateVmFirmware の要求パラメータを firmwareCIMValues に変換する。
+// secureBootTemplate が未知のシンボル名の場合 ok=false を返す (書き込むべき GUID が分からないため)。
+func buildFirmwareCIMValues(
+	enableSecureBoot api.OnOffState,
+	secureBootTemplate string,
+	preferredNetworkBootProtocol api.IPProtocolPreference,
+	consoleMode api.ConsoleModeType,
+	pauseAfterBootFailure api.OnOffState,
+	bootSourceOrder []string,
+) (values firmwareCIMValues, ok bool) {
+	protocol := hyperv.NetworkBootPreferredProtocolIPv4
+	if preferredNetworkBootProtocol == api.IPProtocolPreference_IPv6 {
+		protocol = hyperv.NetworkBootPreferredProtocolIPv6
+	}
+	templateGUID, resolvable := secureBootTemplateNameToGUID(secureBootTemplate)
+	return firmwareCIMValues{
+		secureBoot:             enableSecureBoot == api.OnOffState_On,
+		secureBootTemplateGUID: templateGUID,
+		networkBootProtocol:    protocol,
+		consoleMode:            uint16(consoleMode),
+		pauseAfterBootFailure:  pauseAfterBootFailure == api.OnOffState_On,
+		bootSourceOrder:        bootSourceOrder,
+	}, resolvable
+}
+
+// firmwareWriteNoop は current (現行 CIM 値) と want (書き込み要求値) が完全一致するかを返す。
+// 一致する場合は Set を省略できる (差分なしガード、homelab 既定運用の strict PS-0 維持)。
+func firmwareWriteNoop(current *hyperv.Msvm_VirtualSystemSettingData, want firmwareCIMValues) bool {
+	return current.SecureBoot == want.secureBoot &&
+		current.SecureBootTemplateId == want.secureBootTemplateGUID &&
+		current.NetworkBootPreferredProtocol == want.networkBootProtocol &&
+		current.ConsoleMode == want.consoleMode &&
+		current.PauseAfterBootFailure == want.pauseAfterBootFailure &&
+		stringSlicesEqual(current.BootSourceOrder, want.bootSourceOrder)
+}
+
+// firmwareZeroDowngrade は current → want が「非ゼロ→ゼロ」の遷移を含むかを返す。
+//
+// marshalEmbeddedInstance はゼロ値のフィールドを送信しない (CIM SettingData の「未指定=変更なし」
+// 慣習) ため、この遷移は go-wsman では反映できず「成功報告なのに変わらない」恒常 diff になる
+// (Slice A vm_processor の Fable C パターンと同型)。NetworkBootPreferredProtocol は有効値が
+// 4096/4097 でどちらも非ゼロのため対象外 (常に表現可能)。
+func firmwareZeroDowngrade(current *hyperv.Msvm_VirtualSystemSettingData, want firmwareCIMValues) bool {
+	return (current.SecureBoot && !want.secureBoot) ||
+		(current.PauseAfterBootFailure && !want.pauseAfterBootFailure) ||
+		(current.ConsoleMode != hyperv.ConsoleModeDefault && want.consoleMode == hyperv.ConsoleModeDefault) ||
+		(current.SecureBootTemplateId != "" && want.secureBootTemplateGUID == "") ||
+		(len(current.BootSourceOrder) > 0 && len(want.bootSourceOrder) == 0)
+}
+
+// applyFirmwareSettings は want を sd に反映する。sd は呼び出し側が InstanceID のみを設定した
+// 最小インスタンス (UpdateVm に送る「変更箇所 + InstanceID」だけの instance、他フィールドは
+// ゼロ値のまま = 未指定として扱われる)。
+func applyFirmwareSettings(sd *hyperv.Msvm_VirtualSystemSettingData, want firmwareCIMValues) {
+	sd.SecureBoot = want.secureBoot
+	sd.SecureBootTemplateId = want.secureBootTemplateGUID
+	sd.NetworkBootPreferredProtocol = want.networkBootProtocol
+	sd.ConsoleMode = want.consoleMode
+	sd.PauseAfterBootFailure = want.pauseAfterBootFailure
+	sd.BootSourceOrder = want.bootSourceOrder
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// CreateOrUpdateVmFirmware は VM の Gen2 ファームウェア設定を go-wsman 経由で書き込む。
+//
+// PS 版 (Set-VMFirmware) をシャドウイングする。GetSystemSettingData で現行設定を取得し (この取得は
+// GetVmFirmware ではなく go-wsman を直接呼ぶ。GetVmFirmware は BootSourceOrder に File 型が
+// 含まれる場合に PS へ委譲することがあり、書き込みが表現可能でも読み取り経路で PS が発火してしまう
+// ため)、以下の順で処理する:
+//
+//  1. boot order 解決: bootOrders が非空なら NIC/DVD/HardDisk と突き合わせて WMI 参照文字列に変換
+//     (resolveBootSourceRefsForVM)。解決失敗は go-wsman で表現できないケースとして PS へ委譲。
+//  2. 差分なしガード: 現行値と要求値が完全一致なら Set を省略 (書き込み 0 件)。
+//  3. ゼロ/false ダウングレードの PS 委譲: firmwareZeroDowngrade を参照。
+//  4. UpdateVm (ModifySystemSettings) で書き戻し。InstanceID + firmware 関連フィールドのみを持つ
+//     **最小インスタンス**を送る (bug_sweep_integration_test.go の実機実証パターンと同じ)。
+//     current をまるごとコピーして一部だけ書き換えたインスタンスを送ると、firmware と無関係な
+//     フィールド (VirtualNumaEnabled 等、round-trip 未検証) が ModifySystemSettings に
+//     Exception (ErrorCode=32768「変数の種類が間違っています」) で拒否されることを実機で確認した。
+func (c *ClientConfig) CreateOrUpdateVmFirmware(
+	ctx context.Context,
+	vmName string,
+	bootOrders []api.Gen2BootOrder,
+	enableSecureBoot api.OnOffState,
+	secureBootTemplate string,
+	preferredNetworkBootProtocol api.IPProtocolPreference,
+	consoleMode api.ConsoleModeType,
+	pauseAfterBootFailure api.OnOffState,
+) error {
+	guid, err := c.resolveVMGUID(ctx, vmName)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmFirmware %q: %w", vmName, err)
+	}
+	current, err := c.WsmanClient.GetSystemSettingData(ctx, guid)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmFirmware %q: get: %w", vmName, err)
+	}
+
+	delegate := func() error {
+		return c.ClientConfig.CreateOrUpdateVmFirmware(ctx, vmName, bootOrders,
+			enableSecureBoot, secureBootTemplate, preferredNetworkBootProtocol, consoleMode, pauseAfterBootFailure)
+	}
+
+	var bootSourceOrder []string
+	if len(bootOrders) > 0 {
+		bootSourceOrder, err = c.resolveBootSourceRefsForVM(ctx, vmName, bootOrders)
+		if err != nil {
+			log.Printf("[DEBUG][hyperv-wsman] CreateOrUpdateVmFirmware %q: boot order 解決に失敗、PS へ委譲します: %v", vmName, err)
+			return delegate()
+		}
+	}
+
+	want, templateResolvable := buildFirmwareCIMValues(
+		enableSecureBoot, secureBootTemplate, preferredNetworkBootProtocol, consoleMode, pauseAfterBootFailure, bootSourceOrder)
+	if !templateResolvable {
+		log.Printf("[DEBUG][hyperv-wsman] CreateOrUpdateVmFirmware %q: SecureBootTemplate %q のGUIDが不明、PS へ委譲します", vmName, secureBootTemplate)
+		return delegate()
+	}
+
+	if firmwareWriteNoop(current, want) {
+		return nil
+	}
+	if firmwareZeroDowngrade(current, want) {
+		log.Printf("[DEBUG][hyperv-wsman] CreateOrUpdateVmFirmware %q: ゼロ値ダウングレードを検出、PS へ委譲します", vmName)
+		return delegate()
+	}
+
+	mod := &hyperv.Msvm_VirtualSystemSettingData{InstanceID: current.InstanceID}
+	applyFirmwareSettings(mod, want)
+	jobRef, err := c.WsmanClient.UpdateVm(ctx, mod)
+	if err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmFirmware %q: set: %w", vmName, err)
+	}
+	if err := c.WsmanClient.WaitForJob(ctx, jobRef); err != nil {
+		return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmFirmware %q: wait: %w", vmName, err)
+	}
+	return nil
+}
+
+// resolveBootSourceRefsForVM は VM の NIC/DVD/HardDisk 一覧を取得し、resolveBootSourceRefs に渡す
+// (resolveBootOrdersForVM の書き込み版、resolveBootOrders の逆変換)。
+func (c *ClientConfig) resolveBootSourceRefsForVM(ctx context.Context, vmName string, bootOrders []api.Gen2BootOrder) ([]string, error) {
+	nicRefs, err := c.getNetworkAdapterRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	dvdRefs, err := c.getDvdDriveRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	diskRefs, err := c.getHardDiskDriveRefs(ctx, vmName)
+	if err != nil {
+		return nil, err
+	}
+	return resolveBootSourceRefs(c.WsmanClient.BootSourceRef, bootOrders, nicRefs, dvdRefs, diskRefs)
+}
+
+// CreateOrUpdateVmFirmwares は CreateOrUpdateVmFirmware への 1 件ラッパー (PS 版と同じ契約)。
+func (c *ClientConfig) CreateOrUpdateVmFirmwares(ctx context.Context, vmName string, vmFirmwares []api.VmFirmware) error {
+	if len(vmFirmwares) == 0 {
+		return nil
+	}
+	if len(vmFirmwares) > 1 {
+		return fmt.Errorf("hyperv-wsman: CreateOrUpdateVmFirmwares %q: only 1 vm firmware setting allowed per a vm", vmName)
+	}
+	fw := vmFirmwares[0]
+	return c.CreateOrUpdateVmFirmware(ctx, vmName, fw.BootOrders,
+		fw.EnableSecureBoot, fw.SecureBootTemplate, fw.PreferredNetworkBootProtocol, fw.ConsoleMode, fw.PauseAfterBootFailure)
+}

--- a/api/hyperv-wsman/vm_firmware_write.go
+++ b/api/hyperv-wsman/vm_firmware_write.go
@@ -4,10 +4,24 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 
 	"github.com/r4sd/go-wsman/hyperv"
 	"github.com/taliesins/terraform-provider-hyperv/api"
 )
+
+// clampUint16 は int を uint16 に安全に縮小する (負値は 0、上限超過は MaxUint16 にクランプ)。
+// 直接 uint16(v) すると CodeQL が上限チェックなしの縮小変換 (high) として検出するため
+// (clampUint32 と同じ理由、vm.go 参照)。
+func clampUint16(v int) uint16 {
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxUint16 {
+		return math.MaxUint16
+	}
+	return uint16(v)
+}
 
 // firmwareCIMValues は CreateOrUpdateVmFirmware の要求パラメータを CIM (Msvm_VirtualSystemSettingData)
 // の形に変換した値。判定・適用ロジックをネットワーク呼び出しから切り離してテスト可能にするための型。
@@ -39,7 +53,7 @@ func buildFirmwareCIMValues(
 		secureBoot:             enableSecureBoot == api.OnOffState_On,
 		secureBootTemplateGUID: templateGUID,
 		networkBootProtocol:    protocol,
-		consoleMode:            uint16(consoleMode),
+		consoleMode:            clampUint16(int(consoleMode)),
 		pauseAfterBootFailure:  pauseAfterBootFailure == api.OnOffState_On,
 		bootSourceOrder:        bootSourceOrder,
 	}, resolvable

--- a/api/hyperv-wsman/vm_firmware_write_test.go
+++ b/api/hyperv-wsman/vm_firmware_write_test.go
@@ -66,6 +66,40 @@ func TestFirmwareWriteNoop(t *testing.T) {
 	}
 }
 
+// TestFirmwareWriteNoop_BootSourceOrderFormatMismatch は current.BootSourceOrder (サーバが返す
+// 実機形式、ホスト前置+シングルバックスラッシュ) と want.bootSourceOrder (BootSourceRef=
+// wmiObjectPath が組み立てるクライアント側形式、ホスト前置なし+ダブルバックスラッシュエスケープ+
+// フォワードスラッシュ namespace) が、生文字列としては一致しなくても同じデバイスを指す限り
+// no-op と判定されることを検証する (Fable 指摘: 正規化なしでは差分なしガードが常に false になり
+// 機能しない)。
+func TestFirmwareWriteNoop_BootSourceOrderFormatMismatch(t *testing.T) {
+	current := &hyperv.Msvm_VirtualSystemSettingData{
+		// サーバ実機形式 (シングルバックスラッシュ、ホスト前置あり)。
+		BootSourceOrder: []string{
+			`\\HOST\root\virtualization\v2:Msvm_BootSourceSettingData.InstanceID="Microsoft:vm-guid\nic-guid\B"`,
+		},
+	}
+	want := firmwareCIMValues{
+		// クライアント側 (BootSourceRef/wmiObjectPath) 形式 (ダブルバックスラッシュ、ホスト前置なし、
+		// namespace がフォワードスラッシュ)。同じデバイスを指す。
+		bootSourceOrder: []string{
+			`root/virtualization/v2:Msvm_BootSourceSettingData.InstanceID="Microsoft:vm-guid\\nic-guid\\B"`,
+		},
+	}
+	if !firmwareWriteNoop(current, want) {
+		t.Error("形式が違うだけで同一デバイスを指す BootSourceOrder は no-op と判定されるべき")
+	}
+
+	wantDifferentDevice := firmwareCIMValues{
+		bootSourceOrder: []string{
+			`root/virtualization/v2:Msvm_BootSourceSettingData.InstanceID="Microsoft:vm-guid\\other-nic\\B"`,
+		},
+	}
+	if firmwareWriteNoop(current, wantDifferentDevice) {
+		t.Error("異なるデバイスを指す BootSourceOrder は no-op と判定されるべきではない")
+	}
+}
+
 // TestFirmwareZeroDowngrade は marshalEmbeddedInstance がゼロ値を送信しないために go-wsman では
 // 表現できない「非ゼロ→ゼロ」遷移を正しく検出することを検証する (Slice A Fable C と同型のリスク)。
 func TestFirmwareZeroDowngrade(t *testing.T) {

--- a/api/hyperv-wsman/vm_firmware_write_test.go
+++ b/api/hyperv-wsman/vm_firmware_write_test.go
@@ -1,0 +1,173 @@
+package hyperv_wsman
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+)
+
+func TestBuildFirmwareCIMValues(t *testing.T) {
+	values, ok := buildFirmwareCIMValues(
+		api.OnOffState_On, "MicrosoftWindows", api.IPProtocolPreference_IPv6, api.ConsoleModeType_Com1, api.OnOffState_On,
+		[]string{"ref-1"},
+	)
+	if !ok {
+		t.Fatal("既知のテンプレート名は resolvable であるべき")
+	}
+	want := firmwareCIMValues{
+		secureBoot:             true,
+		secureBootTemplateGUID: secureBootTemplateMicrosoftWindowsGUID,
+		networkBootProtocol:    hyperv.NetworkBootPreferredProtocolIPv6,
+		consoleMode:            uint16(api.ConsoleModeType_Com1),
+		pauseAfterBootFailure:  true,
+		bootSourceOrder:        []string{"ref-1"},
+	}
+	if !reflect.DeepEqual(values, want) {
+		t.Errorf("buildFirmwareCIMValues:\ngot  %+v\nwant %+v", values, want)
+	}
+}
+
+func TestBuildFirmwareCIMValues_UnknownTemplate(t *testing.T) {
+	_, ok := buildFirmwareCIMValues(
+		api.OnOffState_Off, "SomeUnknownTemplate", api.IPProtocolPreference_IPv4, api.ConsoleModeType_Default, api.OnOffState_Off, nil,
+	)
+	if ok {
+		t.Error("未知のテンプレート名は resolvable=false であるべき")
+	}
+}
+
+func TestFirmwareWriteNoop(t *testing.T) {
+	current := &hyperv.Msvm_VirtualSystemSettingData{
+		SecureBoot:                   true,
+		SecureBootTemplateId:         secureBootTemplateMicrosoftWindowsGUID,
+		NetworkBootPreferredProtocol: hyperv.NetworkBootPreferredProtocolIPv4,
+		ConsoleMode:                  hyperv.ConsoleModeDefault,
+		PauseAfterBootFailure:        false,
+		BootSourceOrder:              []string{"ref-1"},
+	}
+	same := firmwareCIMValues{
+		secureBoot:             true,
+		secureBootTemplateGUID: secureBootTemplateMicrosoftWindowsGUID,
+		networkBootProtocol:    hyperv.NetworkBootPreferredProtocolIPv4,
+		consoleMode:            hyperv.ConsoleModeDefault,
+		pauseAfterBootFailure:  false,
+		bootSourceOrder:        []string{"ref-1"},
+	}
+	if !firmwareWriteNoop(current, same) {
+		t.Error("完全一致は no-op と判定されるべき")
+	}
+
+	diff := same
+	diff.consoleMode = hyperv.ConsoleModeCOM1
+	if firmwareWriteNoop(current, diff) {
+		t.Error("差分がある場合は no-op と判定されるべきではない")
+	}
+}
+
+// TestFirmwareZeroDowngrade は marshalEmbeddedInstance がゼロ値を送信しないために go-wsman では
+// 表現できない「非ゼロ→ゼロ」遷移を正しく検出することを検証する (Slice A Fable C と同型のリスク)。
+func TestFirmwareZeroDowngrade(t *testing.T) {
+	tests := []struct {
+		name          string
+		current       *hyperv.Msvm_VirtualSystemSettingData
+		want          firmwareCIMValues
+		wantDowngrade bool
+	}{
+		{
+			name:          "SecureBoot true→false は非表現",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{SecureBoot: true},
+			want:          firmwareCIMValues{secureBoot: false},
+			wantDowngrade: true,
+		},
+		{
+			name:          "SecureBoot false→true は表現可能",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{SecureBoot: false},
+			want:          firmwareCIMValues{secureBoot: true},
+			wantDowngrade: false,
+		},
+		{
+			name:          "PauseAfterBootFailure true→false は非表現",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{PauseAfterBootFailure: true},
+			want:          firmwareCIMValues{pauseAfterBootFailure: false},
+			wantDowngrade: true,
+		},
+		{
+			name:          "ConsoleMode COM1→Default は非表現",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{ConsoleMode: hyperv.ConsoleModeCOM1},
+			want:          firmwareCIMValues{consoleMode: hyperv.ConsoleModeDefault},
+			wantDowngrade: true,
+		},
+		{
+			name:          "ConsoleMode Default→COM1 は表現可能",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{ConsoleMode: hyperv.ConsoleModeDefault},
+			want:          firmwareCIMValues{consoleMode: hyperv.ConsoleModeCOM1},
+			wantDowngrade: false,
+		},
+		{
+			name:          "SecureBootTemplateId 非空→空 は非表現",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{SecureBootTemplateId: secureBootTemplateMicrosoftWindowsGUID},
+			want:          firmwareCIMValues{secureBootTemplateGUID: ""},
+			wantDowngrade: true,
+		},
+		{
+			name:          "BootSourceOrder 非空→空 は非表現",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{BootSourceOrder: []string{"ref-1"}},
+			want:          firmwareCIMValues{bootSourceOrder: nil},
+			wantDowngrade: true,
+		},
+		{
+			name:          "全て変更なしはダウングレードではない",
+			current:       &hyperv.Msvm_VirtualSystemSettingData{},
+			want:          firmwareCIMValues{},
+			wantDowngrade: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firmwareZeroDowngrade(tt.current, tt.want); got != tt.wantDowngrade {
+				t.Errorf("firmwareZeroDowngrade: got %v, want %v", got, tt.wantDowngrade)
+			}
+		})
+	}
+}
+
+// TestApplyFirmwareSettings_RoundTrip は apply がフィールドを漏れなく反映することを検証する
+// (単位変換なしの直接代入だが、フィールド追加時の反映漏れを防ぐための round-trip 確認)。
+func TestApplyFirmwareSettings_RoundTrip(t *testing.T) {
+	sd := &hyperv.Msvm_VirtualSystemSettingData{InstanceID: "keep-me"}
+	want := firmwareCIMValues{
+		secureBoot:             true,
+		secureBootTemplateGUID: secureBootTemplateMicrosoftWindowsGUID,
+		networkBootProtocol:    hyperv.NetworkBootPreferredProtocolIPv6,
+		consoleMode:            hyperv.ConsoleModeCOM2,
+		pauseAfterBootFailure:  true,
+		bootSourceOrder:        []string{"ref-1", "ref-2"},
+	}
+	applyFirmwareSettings(sd, want)
+
+	if sd.InstanceID != "keep-me" {
+		t.Errorf("InstanceID は保持されるべき: got %q", sd.InstanceID)
+	}
+	if !sd.SecureBoot || sd.SecureBootTemplateId != want.secureBootTemplateGUID ||
+		sd.NetworkBootPreferredProtocol != want.networkBootProtocol ||
+		sd.ConsoleMode != want.consoleMode || !sd.PauseAfterBootFailure ||
+		!reflect.DeepEqual(sd.BootSourceOrder, want.bootSourceOrder) {
+		t.Errorf("applyFirmwareSettings: got %+v", sd)
+	}
+}
+
+func TestCreateOrUpdateVmFirmwares_Guards(t *testing.T) {
+	c := &ClientConfig{} // WsmanClient も埋め込み winrm も nil
+	if err := c.CreateOrUpdateVmFirmwares(t.Context(), "vm", nil); err != nil {
+		t.Errorf("空リストは no-op であるべき: %v", err)
+	}
+	if err := c.CreateOrUpdateVmFirmwares(t.Context(), "vm", []api.VmFirmware{}); err != nil {
+		t.Errorf("空スライスは no-op であるべき: %v", err)
+	}
+	err := c.CreateOrUpdateVmFirmwares(t.Context(), "vm", []api.VmFirmware{{}, {}})
+	if err == nil {
+		t.Error("2 件以上はエラーを返すべき")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803
+	github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/r4sd/go-wsman v0.0.0-20260725061754-b581e71a9035 h1:UFBOHn096Qmjr+/0p
 github.com/r4sd/go-wsman v0.0.0-20260725061754-b581e71a9035/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803 h1:Rtr7oZyhy8SfaFQkitZfxZ1OlpUj1TyTriU6nn4Ohno=
 github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
+github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb h1:FpajNGrbmcwdFYl7Mt5aTYRU1gYpotHa3C8lYDiXWZg=
+github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/firmware_write_integration_test.go
+++ b/internal/provider/firmware_write_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の CreateOrUpdateVmFirmware (WRITE) の実機統合テスト。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	go test -tags integration ./internal/provider/ -run TestRealHostFirmwareWriteWsman -v
+
+import (
+	"context"
+	"testing"
+
+	"github.com/r4sd/go-wsman/hyperv"
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+// newRealHostWsmanClientConfig は HYPERV_USE_WSMAN=1 (実 PS フォールバック付き) で
+// *hyperv_wsman.ClientConfig を構築する。GetVmFirmware の READ 統合テストと異なり、本テストは
+// ゼロ値ダウングレードの PS 委譲が実際に動くことまで検証するため、埋め込み winrm を nil にせず
+// Config.Client() の通常経路 (getHypervProvider) をそのまま使う。
+func newRealHostWsmanClientConfig(t *testing.T, c *Config) *hyperv_wsman.ClientConfig {
+	t.Helper()
+	t.Setenv("HYPERV_USE_WSMAN", "1")
+	client, err := c.Client()
+	if err != nil {
+		t.Fatalf("Config.Client(): %v", err)
+	}
+	cc, ok := client.(*hyperv_wsman.ClientConfig)
+	if !ok {
+		t.Fatalf("Config.Client(): got %T, want *hyperv_wsman.ClientConfig (HYPERV_USE_WSMAN が有効か確認)", client)
+	}
+	return cc
+}
+
+// TestRealHostFirmwareWriteWsman は CreateOrUpdateVmFirmware の go-wsman 書き込み経路を実機で検証する。
+//
+// 2 段階で確認する:
+//  1. 表現可能な変更 (ConsoleMode Default→COM1、PreferredNetworkBootProtocol IPv4→IPv6、
+//     BootOrders の並び替え) を書き込み、再読み取りで反映されていることを確認する。特に BootOrders は
+//     resolveBootSourceRefs (書き込み) → resolveBootOrders (読み取り) の round-trip が実機で正しく
+//     機能するかが Slice D READ 時点の未検証事項だった (advisor 指摘)。
+//  2. ゼロ値ダウングレード (ConsoleMode COM1→Default) を書き込み、PS (embedded winrm) への委譲が
+//     黙って失敗せず実際に反映されることを確認する (Slice A Fable C と同型のリグレッションが
+//     ここでも起きていないことの実機証跡)。
+func TestRealHostFirmwareWriteWsman(t *testing.T) {
+	c := realHostConfigFromEnv(t)
+	cc := newRealHostWsmanClientConfig(t, c)
+	wsmanClient := cc.WsmanClient
+	ctx := context.Background()
+
+	const vmName = "tf-wsman-firmware-write-test"
+	_ = cc.DeleteVm(ctx, vmName)
+	t.Cleanup(func() {
+		if err := cc.DeleteVm(ctx, vmName); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+
+	const memByt = 536870912
+	if err := cc.CreateVm(ctx, vmName,
+		"", 2, // Generation 2
+		api.CriticalErrorAction_Pause, 0,
+		api.StartAction_Nothing, 0,
+		api.StopAction_Save,
+		api.CheckpointType_Production,
+		false, false, 0,
+		api.OnOffState_Off, 0,
+		memByt, memByt, memByt,
+		"firmware-write-test", 1,
+		"", "", true, false,
+	); err != nil {
+		t.Fatalf("CreateVm: %v", err)
+	}
+
+	vm, err := wsmanClient.FindComputerSystemByElementName(ctx, vmName)
+	if err != nil {
+		t.Fatalf("FindComputerSystemByElementName: %v", err)
+	}
+	vmGUID := vm.Name
+
+	// NIC (スイッチ接続なし、go-wsman #114 の影響を避ける)。
+	nicRes, err := wsmanClient.AddNetworkAdapter(ctx, vmGUID, hyperv.NetworkAdapterOptions{ElementName: "eth0-writetest"})
+	if err != nil {
+		t.Fatalf("AddNetworkAdapter: %v", err)
+	}
+	if nicRes.JobRef != "" {
+		if err := wsmanClient.WaitForJob(ctx, nicRes.JobRef); err != nil {
+			t.Fatalf("WaitForJob(AddNetworkAdapter): %v", err)
+		}
+	}
+
+	scsiRes, err := wsmanClient.AddScsiController(ctx, vmGUID)
+	if err != nil {
+		t.Fatalf("AddScsiController: %v", err)
+	}
+	if scsiRes.JobRef != "" {
+		if err := wsmanClient.WaitForJob(ctx, scsiRes.JobRef); err != nil {
+			t.Fatalf("WaitForJob(AddScsiController): %v", err)
+		}
+	}
+
+	const isoPath = `H:\ISO\ubuntu-24.04.4-live-server-amd64.iso`
+	dvdRes, err := wsmanClient.AttachDVD(ctx, vmGUID, hyperv.AttachDVDOptions{
+		ControllerType: hyperv.ControllerTypeSCSI, ControllerNumber: 0, ControllerLocation: 0, Path: isoPath,
+	})
+	if err != nil {
+		t.Fatalf("AttachDVD: %v", err)
+	}
+	if dvdRes.JobRef != "" {
+		if err := wsmanClient.WaitForJob(ctx, dvdRes.JobRef); err != nil {
+			t.Fatalf("WaitForJob(AttachDVD): %v", err)
+		}
+	}
+
+	baseline, err := cc.GetVmFirmware(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmFirmware (baseline): %v", err)
+	}
+	if len(baseline.BootOrders) != 2 {
+		t.Fatalf("baseline BootOrders件数: got %d, want 2 (NIC+DVD)", len(baseline.BootOrders))
+	}
+	t.Logf("baseline.BootOrders: %+v", baseline.BootOrders)
+
+	// 並び替え (逆順) にして、書き込みが実際に順序へ反映されるかを確認する。
+	reordered := []api.Gen2BootOrder{baseline.BootOrders[1], baseline.BootOrders[0]}
+
+	// --- 1. 表現可能な変更 ---
+	if err := cc.CreateOrUpdateVmFirmware(ctx, vmName,
+		reordered,
+		baseline.EnableSecureBoot,      // 変更なし (On のまま)
+		baseline.SecureBootTemplate,    // 変更なし (MicrosoftWindows のまま)
+		api.IPProtocolPreference_IPv6,  // IPv4→IPv6 (両方非ゼロ、常に表現可能)
+		api.ConsoleModeType_Com1,       // Default(0)→COM1(非ゼロ)、表現可能
+		baseline.PauseAfterBootFailure, // 変更なし (Off のまま)
+	); err != nil {
+		t.Fatalf("CreateOrUpdateVmFirmware (representable changes): %v", err)
+	}
+
+	afterWrite, err := cc.GetVmFirmware(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmFirmware (after write): %v", err)
+	}
+	t.Logf("afterWrite: %+v", afterWrite)
+
+	if afterWrite.PreferredNetworkBootProtocol != api.IPProtocolPreference_IPv6 {
+		t.Errorf("PreferredNetworkBootProtocol: got %v, want IPv6", afterWrite.PreferredNetworkBootProtocol)
+	}
+	if afterWrite.ConsoleMode != api.ConsoleModeType_Com1 {
+		t.Errorf("ConsoleMode: got %v, want COM1", afterWrite.ConsoleMode)
+	}
+	if afterWrite.EnableSecureBoot != baseline.EnableSecureBoot {
+		t.Errorf("EnableSecureBoot: got %v, want unchanged (%v)", afterWrite.EnableSecureBoot, baseline.EnableSecureBoot)
+	}
+	if len(afterWrite.BootOrders) != 2 {
+		t.Fatalf("afterWrite BootOrders件数: got %d, want 2", len(afterWrite.BootOrders))
+	}
+	if afterWrite.BootOrders[0].Type != reordered[0].Type || afterWrite.BootOrders[1].Type != reordered[1].Type {
+		t.Errorf("BootOrders の並び替えが反映されていない: got %+v, want順序 %+v", afterWrite.BootOrders, reordered)
+	} else {
+		t.Logf("✅ BootOrders の書き込み→読み取り round-trip を実機で確認 (resolveBootSourceRefs⇄resolveBootOrders)")
+	}
+	t.Logf("✅ 表現可能な変更 (ConsoleMode/PreferredNetworkBootProtocol/BootOrders並び替え) を go-wsman 経由で確認")
+
+	// --- 2. ゼロ値ダウングレード (ConsoleMode COM1→Default) は PS へ委譲され、黙って失敗しない ---
+	if err := cc.CreateOrUpdateVmFirmware(ctx, vmName,
+		reordered,
+		afterWrite.EnableSecureBoot,
+		afterWrite.SecureBootTemplate,
+		afterWrite.PreferredNetworkBootProtocol,
+		api.ConsoleModeType_Default, // COM1→Default (非ゼロ→ゼロ、go-wsman では非表現)
+		afterWrite.PauseAfterBootFailure,
+	); err != nil {
+		t.Fatalf("CreateOrUpdateVmFirmware (zero downgrade, PS委譲想定): %v", err)
+	}
+
+	afterDowngrade, err := cc.GetVmFirmware(ctx, vmName)
+	if err != nil {
+		t.Fatalf("GetVmFirmware (after downgrade): %v", err)
+	}
+	if afterDowngrade.ConsoleMode != api.ConsoleModeType_Default {
+		t.Errorf("ConsoleMode (PS委譲後): got %v, want Default。PS 委譲が黙って失敗し変更が反映されていない可能性あり", afterDowngrade.ConsoleMode)
+	} else {
+		t.Logf("✅ ゼロ値ダウングレードの PS 委譲が実際に反映されることを確認 (silent-drop していない)")
+	}
+}

--- a/internal/provider/full_lifecycle_strict_integration_test.go
+++ b/internal/provider/full_lifecycle_strict_integration_test.go
@@ -1,0 +1,226 @@
+//go:build integration
+// +build integration
+
+package provider
+
+// go-wsman 経由の VM フルライフサイクル (Slice E, #80) の strict モード実機統合テスト。
+//
+// Create→NIC追加→Processor/Firmware の既定値書き込み→各種 Read→Destroy の一周を、埋め込み
+// WinRmClient を fail-fast スタブ (StrictNoPSClient) に差し替えた ClientConfig で実行し、
+// homelab の既定運用 (Gen2 VM、NIC はスイッチ接続なし、wait_for_ips=false、processor/firmware は
+// 既定値のまま) が PowerShell フォールバックを 1 件も呼ばないこと (PS-0) を陽性証明する。
+// IntegrationServices は既知の問題 (#98、下記) によりこの Slice では対象外。
+//
+// Slice D (firmware read/write shadow) 完了により、strict_read_integration_test.go の
+// コメントにあった「Gen2 は GetVmFirmwares 未シャドウのため PS-0 未達」という制約は解消された
+// (BootSourceOrder が File 型を含まず解決可能な限り)。本テストはその解消を実機で確認する。
+//
+// NIC はスイッチ接続なしで追加する (go-wsman #114: 新規VM直後のスイッチ接続が ErrorCode=32773 で
+// 失敗する既知バグのため、本テストのスコープ外として回避する)。
+//
+// negative control 必須 (DoD §4): 恒真アサーションを避けるため、strict ハーネスが実際に
+// PS フォールバックを検知できることを別の strict インスタンスで証明する。
+//   1. firmware のゼロ値ダウングレード書き込み (ConsoleMode COM1→Default) は PS へ委譲される。
+//   2. wait_for_ips=true は WaitForVmNetworkAdaptersIps を PS へ委譲する (#76)。
+//
+// 実行例:
+//
+//	HYPERV_HOST=10.0.0.100 HYPERV_USER=terraform HYPERV_PASSWORD=... \
+//	HYPERV_PORT=5986 HYPERV_HTTPS=true HYPERV_INSECURE=true HYPERV_USE_NTLM=true \
+//	go test -tags integration ./internal/provider/ -run TestRealHostFullLifecycleStrictPS0 -v
+
+import (
+	"context"
+	"testing"
+
+	"github.com/taliesins/terraform-provider-hyperv/api"
+	hyperv_winrm "github.com/taliesins/terraform-provider-hyperv/api/hyperv-winrm"
+	hyperv_wsman "github.com/taliesins/terraform-provider-hyperv/api/hyperv-wsman"
+)
+
+func TestRealHostFullLifecycleStrictPS0(t *testing.T) {
+	c := realHostConfigFromEnv(t)
+	wsmanClient, err := newWsmanClient(c)
+	if err != nil {
+		t.Fatalf("newWsmanClient: %v", err)
+	}
+
+	strict := &hyperv_wsman.StrictNoPSClient{}
+	cc := &hyperv_wsman.ClientConfig{
+		ClientConfig: &hyperv_winrm.ClientConfig{WinRmClient: strict},
+		WsmanClient:  wsmanClient,
+	}
+	ctx := context.Background()
+
+	mustNoPS := func(label string, err error) {
+		t.Helper()
+		if err != nil {
+			t.Errorf("%s: エラー (PS フォールバックの可能性): %v", label, err)
+		}
+	}
+
+	const (
+		vmName = "tf-wsman-full-lifecycle-test"
+		memByt = 536870912
+	)
+	// strict でない普通の ClientConfig で前回残骸を掃除 (DeleteVm 自体は shadow 済みなので不要だが、
+	// cleanup 経路のエラーを strict カウンタに混ぜないため専用インスタンスを使う)。
+	cleanupCC := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient}
+	_ = cleanupCC.DeleteVm(ctx, vmName)
+	t.Cleanup(func() {
+		if err := cleanupCC.DeleteVm(ctx, vmName); err != nil {
+			t.Logf("cleanup DeleteVm: %v", err)
+		}
+	})
+
+	// --- 1. Create (Gen2) ---
+	mustNoPS("CreateVm", cc.CreateVm(ctx, vmName,
+		"", 2,
+		api.CriticalErrorAction_Pause, 0,
+		api.StartAction_Nothing, 0,
+		api.StopAction_Save,
+		api.CheckpointType_Production,
+		false, false, 0,
+		api.OnOffState_Off, 0,
+		memByt, memByt, memByt,
+		"full-lifecycle-test", 1,
+		"", "", true, false,
+	))
+
+	vm, err := cc.GetVm(ctx, vmName)
+	mustNoPS("GetVm", err)
+	if vm.Generation != 2 {
+		t.Fatalf("Generation: got %d, want 2", vm.Generation)
+	}
+
+	// --- 2. NIC (スイッチ接続なし、go-wsman #114 回避) ---
+	// go-wsman 経路は NIC 本体+スイッチ接続+MAC のみ対応 (unsupportedNetworkAdapterOptions)。
+	// それ以外のフィールドは schema 既定値のまま渡す必要がある (Go のゼロ値と既定値が異なる
+	// OnOffState 等が多いため、ゼロ値のまま渡すと「未対応オプション」エラーになる)。
+	mustNoPS("CreateOrUpdateVmNetworkAdapters", cc.CreateOrUpdateVmNetworkAdapters(ctx, vmName, []api.VmNetworkAdapter{
+		defaultLifecycleNetworkAdapter("eth0-lifecycle"),
+	}))
+
+	// --- 3. Processor: 既定値のまま書き戻す (差分なしガードで PS-0) ---
+	procs, err := cc.GetVmProcessors(ctx, vmName)
+	mustNoPS("GetVmProcessors", err)
+	if len(procs) == 1 {
+		mustNoPS("CreateOrUpdateVmProcessors(no-op)", cc.CreateOrUpdateVmProcessors(ctx, vmName, procs))
+	}
+
+	// --- 4. IntegrationServices ---
+	// GetVmIntegrationServices の結果をそのまま CreateOrUpdateVmIntegrationServices に渡す
+	// round-trip は非英語ロケールの Hyper-V ホストで失敗する既知の問題 (#98、ElementName が
+	// ローカライズされる一方 go-wsman の component 解決は英語 canonical 名のみ受理するため)。
+	// この Slice ではフルライフサイクルの PS-0 証明に IS 書き込みは必須ではないため、
+	// 既知の問題を踏まないよう本テストではこの leg を省略する。
+	_, err = cc.GetVmIntegrationServices(ctx, vmName)
+	mustNoPS("GetVmIntegrationServices", err)
+
+	// --- 5. Firmware: 既定値のまま書き戻す (差分なしガードで PS-0) ---
+	fw, err := cc.GetVmFirmware(ctx, vmName)
+	mustNoPS("GetVmFirmware", err)
+	mustNoPS("CreateOrUpdateVmFirmware(no-op)", cc.CreateOrUpdateVmFirmware(ctx, vmName,
+		fw.BootOrders, fw.EnableSecureBoot, fw.SecureBootTemplate,
+		fw.PreferredNetworkBootProtocol, fw.ConsoleMode, fw.PauseAfterBootFailure))
+
+	// --- 6. Read 経路 (refresh/plan 相当) ---
+	_, err = cc.GetVmNetworkAdapters(ctx, vmName, nil)
+	mustNoPS("GetVmNetworkAdapters", err)
+	_, err = cc.GetVmHardDiskDrives(ctx, vmName)
+	mustNoPS("GetVmHardDiskDrives", err)
+	_, err = cc.GetVmDvdDrives(ctx, vmName)
+	mustNoPS("GetVmDvdDrives", err)
+	_, err = cc.GetVmGpuAdapters(ctx, vmName)
+	mustNoPS("GetVmGpuAdapters", err)
+	_, err = cc.GetVmStatus(ctx, vmName)
+	mustNoPS("GetVmStatus", err)
+	mustNoPS("WaitForVmNetworkAdaptersIps(all-false)",
+		cc.WaitForVmNetworkAdaptersIps(ctx, vmName, 0, 0, []api.VmNetworkAdapterWaitForIp{{Name: "eth0-lifecycle", WaitForIps: false}}))
+
+	// --- 合格条件: ここまで (Destroy 以外の全ライフサイクル) で PS フォールバック 0 件 ---
+	if calls := strict.Calls(); calls != 0 {
+		t.Errorf("フルライフサイクルで PS フォールバックが %d 件走った (strict 不合格): %v", calls, strict.Labels())
+	} else {
+		t.Logf("✅ Gen2 VM のフルライフサイクル (create→NIC→processor/firmware 既定値→read) は PS 呼び出し 0 件 (strict 合格)")
+	}
+
+	// --- negative control (VM が生きている間に実行。Destroy は最後にまとめて行う) ---
+
+	// negative control 1: firmware ゼロ値ダウングレードは PS へ委譲する ---
+	negCC := &hyperv_wsman.ClientConfig{WsmanClient: wsmanClient} // 通常経路で ConsoleMode=COM1 を作る
+	if err := negCC.CreateOrUpdateVmFirmware(ctx, vmName,
+		fw.BootOrders, fw.EnableSecureBoot, fw.SecureBootTemplate,
+		fw.PreferredNetworkBootProtocol, api.ConsoleModeType_Com1, fw.PauseAfterBootFailure); err != nil {
+		t.Skipf("negative control 前提の ConsoleMode=COM1 設定に失敗: %v", err)
+	}
+	negFw := &hyperv_wsman.StrictNoPSClient{}
+	negFwCC := &hyperv_wsman.ClientConfig{
+		ClientConfig: &hyperv_winrm.ClientConfig{WinRmClient: negFw},
+		WsmanClient:  wsmanClient,
+	}
+	err = negFwCC.CreateOrUpdateVmFirmware(ctx, vmName,
+		fw.BootOrders, fw.EnableSecureBoot, fw.SecureBootTemplate,
+		fw.PreferredNetworkBootProtocol, api.ConsoleModeType_Default, fw.PauseAfterBootFailure)
+	if err == nil {
+		t.Error("negative control: ConsoleMode COM1→Default (ゼロ値ダウングレード) は strict で error になるべき")
+	}
+	if negFw.Calls() == 0 {
+		t.Error("negative control: strict スタブが firmware のゼロ値ダウングレード委譲を検知できていない")
+	} else {
+		t.Logf("✅ negative control(firmware zero-downgrade): PS 委譲が検知された (%v)", negFw.Labels())
+	}
+
+	// --- negative control 2: wait_for_ips=true は PS へ委譲する (#76) ---
+	negWait := &hyperv_wsman.StrictNoPSClient{}
+	negWaitCC := &hyperv_wsman.ClientConfig{
+		ClientConfig: &hyperv_winrm.ClientConfig{WinRmClient: negWait},
+		WsmanClient:  wsmanClient,
+	}
+	err = negWaitCC.WaitForVmNetworkAdaptersIps(ctx, vmName, 0, 0, []api.VmNetworkAdapterWaitForIp{{Name: "eth0-lifecycle", WaitForIps: true}})
+	if err == nil {
+		t.Error("negative control: wait_for_ips=true は PS へ委譲し strict で error になるべき")
+	}
+	if negWait.Calls() == 0 {
+		t.Error("negative control: strict スタブが wait_for_ips=true の PS 委譲を検知できていない")
+	} else {
+		t.Logf("✅ negative control(wait_for_ips=true): PS 委譲が検知された (%v)", negWait.Labels())
+	}
+
+	// --- Destroy (strict カウンタ集計後の後始末、strict でなくてよい) ---
+	if err := cleanupCC.DeleteVm(ctx, vmName); err != nil {
+		t.Fatalf("DeleteVm: %v", err)
+	}
+	ex, err := cleanupCC.VmExists(ctx, vmName)
+	if err != nil {
+		t.Fatalf("VmExists(after delete): %v", err)
+	}
+	if ex.Exists {
+		t.Error("DeleteVm 後も VmExists=true")
+	}
+}
+
+// defaultLifecycleNetworkAdapter は go-wsman 経路 (unsupportedNetworkAdapterOptions) が受理する
+// 既定値で NIC を組み立てる。Go のゼロ値と Hyper-V の既定値が異なるフィールド (OnOffState 系は
+// ゼロ値が On になる等) があるため、Name 以外は明示的に既定値を書く必要がある。
+func defaultLifecycleNetworkAdapter(name string) api.VmNetworkAdapter {
+	return api.VmNetworkAdapter{
+		Name:                                   name,
+		DynamicMacAddress:                      true,
+		MacAddressSpoofing:                     api.OnOffState_Off,
+		DhcpGuard:                              api.OnOffState_Off,
+		RouterGuard:                            api.OnOffState_Off,
+		PortMirroring:                          api.PortMirroring_None,
+		IeeePriorityTag:                        api.OnOffState_Off,
+		VmqWeight:                              100,
+		IovQueuePairsRequested:                 1,
+		IovInterruptModeration:                 api.IovInterruptModerationValue_Off,
+		IovWeight:                              100,
+		IpsecOffloadMaximumSecurityAssociation: 512,
+		AllowTeaming:                           api.OnOffState_On,
+		DeviceNaming:                           api.OnOffState_Off,
+		FixSpeed10G:                            api.OnOffState_Off,
+		VrssEnabled:                            true,
+		VmmqQueuePairs:                         16,
+	}
+}


### PR DESCRIPTION
## Summary

- `CreateOrUpdateVmFirmware`/`CreateOrUpdateVmFirmwares` を go-wsman shadow 実装 (Slice D WRITE)。SecureBoot/SecureBootTemplate/PreferredNetworkBootProtocol/ConsoleMode/PauseAfterBootFailure/BootOrders の書き込みに対応。
- go-wsman 側に `BootSourceRef` primitive を追加 (`resolveBootOrders` の逆変換、PR済み・main反映済み)。
- フルライフサイクル strict (PS-0) 実機テストを追加 (Slice E)。Gen2 VM の Create→NIC追加→Processor/Firmware 既定値書き込み→各種Read が PowerShell フォールバック 0 件で完結することを確認。

## 設計判断

- **最小インスタンス書き込み**: `UpdateVm` (ModifySystemSettings) は `GetSystemSettingData` の全フィールドをコピーして一部だけ書き換えたインスタンスを送るとエラー (ErrorCode=32768「変数の種類が間違っています」) になることを実機で確認。InstanceID + 変更したいフィールドだけの最小インスタンスに変更 (go-wsman 側の実証パターンと一致)。
- **ゼロ値ダウングレードの PS 委譲**: `marshalEmbeddedInstance` は Go のゼロ値フィールドを送信しない設計のため、SecureBoot/PauseAfterBootFailure の true→false、ConsoleMode の非Default→Default、SecureBootTemplate/BootSourceOrder の非空→空は go-wsman で表現できず PS へ委譲する。
- **NIC の一意特定**: BootOrders の NetworkAdapter エントリは PS 版 (Name→SwitchName→MacAddress の順で絞り込み) と同じロジックで一意に解決し、一意に定まらない場合は PS へ委譲する (Fable 敵対レビューで、Name のみの一致だと同名 NIC で誤ったデバイスに書き込む危険を指摘され修正)。

## 実機検証

- `TestRealHostFirmwareWriteWsman`: 表現可能な変更 (ConsoleMode/PreferredNetworkBootProtocol/BootOrders並び替え) の go-wsman 直接書き込み→読み取り round-trip、およびゼロ値ダウングレードの PS 委譲が実際に反映される (silent drop していない) ことを確認。PASS。
- `TestRealHostFullLifecycleStrictPS0`: Gen2 VM の Create→NIC→Processor/Firmware 既定値→Read の全経路が PS 呼び出し 0 件。negative control 2件 (firmware ゼロ値ダウングレード、wait_for_ips=true) で strict ハーネスの検出力も確認。PASS。

## 既知の残スコープ

- IntegrationServices の read→write round-trip は非英語ロケール Hyper-V ホストで失敗する既知の問題のため、Slice E のフルライフサイクルテストは IS を対象外にしている (#98 で追跡)。
- Gen2 VM の既定 (`vm_firmware` 未指定) create は、NIC/DVD 追加後に BootSourceOrder が自動登録され非空になる一方 config 既定は空のため、ゼロ値ダウングレードで毎回 PS 委譲される。full-lifecycle PS-0 は `vm_firmware` を明示的に現状維持で書き戻す構成に限る (#99 で追跡)。
- SecureBootTemplate は "MicrosoftWindows" のみ GUID 対応、大文字小文字比較、Drive の path-only (-1) 指定は未対応 (いずれも安全側で PS 委譲、#100 で追跡)。

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go vet -tags integration ./...` green
- [x] `go test ./... -count=1` (unit) green
- [x] 実機 acc test 4件 (`TestRealHostFirmwareReadWsman` / `TestRealHostFirmwareBootOrderWsman` / `TestRealHostFirmwareWriteWsman` / `TestRealHostFullLifecycleStrictPS0`) PASS
- [x] Fable 敵対レビュー実施、CONFIRMED 指摘 (同名NIC誤バインド、差分なしガードの形式不一致) を修正、実機で再検証済み