### PR TITLE
fix: GetVm の Memory/ProcessorCount 未対応・MMIO 単位変換漏れを修正

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -30,9 +30,11 @@ func (c *ClientConfig) VmExists(ctx context.Context, name string) (api.VmExists,
 // GetVm は go-wsman 経由で VM の構成情報を取得する。
 //
 // 表示名→GUID を解決し、Realized の Msvm_VirtualSystemSettingData を取得して api.Vm に
-// マッピングする。VM レベルの設定 (世代・自動アクション・Notes 等) のみを対象とし、
-// Memory/CPU は別途 Msvm_MemorySettingData / Msvm_ProcessorSettingData が必要なため
-// 本メソッドでは設定しない (vmFromSettingData の注記参照)。
+// マッピングする。Memory/ProcessorCount は別途 Msvm_MemorySettingData /
+// Msvm_ProcessorSettingData を取得して合成する (resource 層の read が
+// vm.DynamicMemory/StaticMemory の排他を検証するため必須。未設定のままだと両方 false の
+// ゼロ値になり「Either dynamic or static must be selected」で実機の全 VM read が失敗する、
+// 実運用移行の実機検証で発見)。
 func (c *ClientConfig) GetVm(ctx context.Context, name string) (api.Vm, error) {
 	cs, err := c.WsmanClient.FindComputerSystemByElementName(ctx, name)
 	if err != nil {
@@ -47,7 +49,57 @@ func (c *ClientConfig) GetVm(ctx context.Context, name string) (api.Vm, error) {
 	if err != nil {
 		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
 	}
-	return vmFromSettingData(name, sd), nil
+	vm := vmFromSettingData(name, sd)
+
+	mem, err := c.WsmanClient.GetMemorySettings(ctx, cs.Name)
+	if err != nil {
+		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: memory: %w", name, err)
+	}
+	applyMemoryToVm(&vm, mem)
+
+	proc, err := c.WsmanClient.GetProcessorSettings(ctx, cs.Name)
+	if err != nil {
+		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: processor: %w", name, err)
+	}
+	vm.ProcessorCount = clampInt64(proc.VirtualQuantity)
+
+	return vm, nil
+}
+
+// applyMemoryToVm は Msvm_MemorySettingData から api.Vm のメモリ関連フィールドを埋める。
+// PS 版 (Get-VMMemory) と同じマッピング: DynamicMemory=DynamicMemoryEnabled /
+// StaticMemory=!DynamicMemoryEnabled / MemoryStartupBytes=VirtualQuantity /
+// MemoryMinimumBytes=Reservation / MemoryMaximumBytes=Limit (いずれも CIM は MB、api は byte)。
+// static memory でも Reservation/Limit は CIM 上 VirtualQuantity と同値で返る (Hyper-V の実装)。
+func applyMemoryToVm(vm *api.Vm, mem *hyperv.Msvm_MemorySettingData) {
+	vm.DynamicMemory = mem.DynamicMemoryEnabled
+	vm.StaticMemory = !mem.DynamicMemoryEnabled
+	vm.MemoryStartupBytes = mbToBytes(mem.VirtualQuantity)
+	vm.MemoryMinimumBytes = mbToBytes(mem.Reservation)
+	vm.MemoryMaximumBytes = mbToBytes(mem.Limit)
+}
+
+// mbToBytes は CIM の MB 単位を byte に変換する。int64 化前に上限をクランプし、
+// 縮小変換の上限チェックなし (CodeQL high) を回避する (clampInt64/clampUint32 と同じ理由)。
+func mbToBytes(mb uint64) int64 {
+	const maxMB = math.MaxInt64 / (1024 * 1024)
+	if mb > maxMB {
+		mb = maxMB
+	}
+	return int64(mb) * 1024 * 1024
+}
+
+// mbToBytesU64 は CIM の MB 単位を byte (uint64) に変換する。mbToBytes の uint64 版
+// (HighMemoryMappedIoSpace 等 uint64 フィールド用)。1024*1024 倍後の桁あふれを避けるため
+// 乗算前に MB 値の上限をクランプする (clampUint32 で uint32 へ絞るのはこの関数の戻り値=
+// バイト値に対して乗算後に適用する。MB の時点で uint32 に絞ると桁あふれと無関係に値を破壊するため
+// 誤り、必ず bytes 変換後に clampUint32 を掛けること)。
+func mbToBytesU64(mb uint64) uint64 {
+	const maxMB = math.MaxUint64 / (1024 * 1024)
+	if mb > maxMB {
+		mb = maxMB
+	}
+	return mb * 1024 * 1024
 }
 
 // vmFromSettingData は Msvm_VirtualSystemSettingData を api.Vm にマッピングする (純関数)。
@@ -66,15 +118,18 @@ func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) ap
 		Notes:                        strings.Join(sd.Notes, "\n"),
 		LockOnDisconnect:             lockOnDisconnectState(sd.LockOnDisconnect),
 		GuestControlledCacheTypes:    sd.GuestControlledCacheTypes,
-		HighMemoryMappedIoSpace:      sd.HighMmioGapSize,
-		LowMemoryMappedIoSpace:       clampUint32(sd.LowMmioGapSize),
-		SnapshotFileLocation:         sd.SnapshotDataRoot,
-		SmartPagingFilePath:          sd.SwapFileDataRoot,
+		// HighMmioGapSize/LowMmioGapSize は CIM 上 MB 単位だが api.Vm (PS版 Get-VM 由来) は
+		// byte 単位のため変換が必要 (実運用移行の実機検証で発見、変換漏れのまま plan すると
+		// 512(MB のまま)→536870912(正しい byte)の恒常 diff になる)。
+		HighMemoryMappedIoSpace: mbToBytesU64(sd.HighMmioGapSize),
+		LowMemoryMappedIoSpace:  clampUint32(mbToBytesU64(sd.LowMmioGapSize)),
+		SnapshotFileLocation:    sd.SnapshotDataRoot,
+		SmartPagingFilePath:     sd.SwapFileDataRoot,
 
 		// 以下は本メソッドでは未設定 (ゼロ値):
-		//   - Memory/CPU (MemoryStartupBytes/Min/Max, DynamicMemory, StaticMemory,
-		//     ProcessorCount): Msvm_MemorySettingData / Msvm_ProcessorSettingData が
-		//     別途必要 (CreateVm/C-2 で対応)。
+		//   - Memory (MemoryStartupBytes/Min/Max, DynamicMemory, StaticMemory) / ProcessorCount:
+		//     呼び出し側の GetVm が Msvm_MemorySettingData / Msvm_ProcessorSettingData を
+		//     別途取得し合成する (applyMemoryToVm / clampInt64(proc.VirtualQuantity))。
 		//   - AutomaticStartDelay / AutomaticCriticalErrorActionTimeout: CIM の
 		//     Duration/interval 文字列パースが必要。実機が返す実書式に合わせるため
 		//     acc test (Phase D) で実データ確認後に実装する。

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -135,11 +135,12 @@ func TestVmFromSettingData(t *testing.T) {
 	if !got.GuestControlledCacheTypes {
 		t.Error("GuestControlledCacheTypes = false, want true")
 	}
-	if got.HighMemoryMappedIoSpace != 512 {
-		t.Errorf("HighMemoryMappedIoSpace = %d, want 512", got.HighMemoryMappedIoSpace)
+	// HighMmioGapSize/LowMmioGapSize は CIM 上 MB、api.Vm は byte (実運用移行の実機検証で発見)。
+	if got.HighMemoryMappedIoSpace != 512*1024*1024 {
+		t.Errorf("HighMemoryMappedIoSpace = %d, want %d (512MiB)", got.HighMemoryMappedIoSpace, uint64(512*1024*1024))
 	}
-	if got.LowMemoryMappedIoSpace != 128 {
-		t.Errorf("LowMemoryMappedIoSpace = %d, want 128", got.LowMemoryMappedIoSpace)
+	if got.LowMemoryMappedIoSpace != 128*1024*1024 {
+		t.Errorf("LowMemoryMappedIoSpace = %d, want %d (128MiB)", got.LowMemoryMappedIoSpace, uint32(128*1024*1024))
 	}
 	if got.Path != `C:\vms\test` {
 		t.Errorf("Path = %q", got.Path)
@@ -287,6 +288,81 @@ func TestApplyMemorySettings(t *testing.T) {
 		}
 		if m.Limit != 4096 {
 			t.Errorf("dynamic: Limit=%d, want 4096", m.Limit)
+		}
+	})
+}
+
+// TestMbToBytes は bytesToMB の逆変換 (READ 側、GetVm が使う) を検証する。
+func TestMbToBytes(t *testing.T) {
+	tests := []struct {
+		mb   uint64
+		want int64
+	}{
+		{0, 0},
+		{1, 1048576},       // 1 MiB
+		{2048, 2147483648}, // 2 GiB
+		{math.MaxUint64, math.MaxInt64 / (1024 * 1024) * (1024 * 1024)}, // 上限クランプ
+	}
+	for _, tt := range tests {
+		if got := mbToBytes(tt.mb); got != tt.want {
+			t.Errorf("mbToBytes(%d)=%d, want %d", tt.mb, got, tt.want)
+		}
+	}
+}
+
+// TestMbToBytesU64 は mbToBytes の uint64 版 (HighMemoryMappedIoSpace 等) を検証する。
+func TestMbToBytesU64(t *testing.T) {
+	tests := []struct {
+		mb   uint64
+		want uint64
+	}{
+		{0, 0},
+		{512, 512 * 1024 * 1024},
+		{math.MaxUint64, math.MaxUint64 / (1024 * 1024) * (1024 * 1024)}, // 上限クランプ
+	}
+	for _, tt := range tests {
+		if got := mbToBytesU64(tt.mb); got != tt.want {
+			t.Errorf("mbToBytesU64(%d)=%d, want %d", tt.mb, got, tt.want)
+		}
+	}
+}
+
+// TestApplyMemoryToVm は Msvm_MemorySettingData → api.Vm のメモリ関連フィールドへのマッピングを
+// 検証する (実運用の実機検証で発見: このマッピングが無いと DynamicMemory/StaticMemory が両方
+// false のゼロ値のままになり、resource read が「Either dynamic or static must be selected」で
+// 実機の全 VM で失敗していた)。
+func TestApplyMemoryToVm(t *testing.T) {
+	t.Run("static (DynamicMemoryEnabled=false)", func(t *testing.T) {
+		vm := &api.Vm{}
+		applyMemoryToVm(vm, &hyperv.Msvm_MemorySettingData{
+			VirtualQuantity: 8192, DynamicMemoryEnabled: false, Reservation: 8192, Limit: 8192,
+		})
+		if vm.DynamicMemory {
+			t.Error("DynamicMemory は false であるべき")
+		}
+		if !vm.StaticMemory {
+			t.Error("StaticMemory は true であるべき")
+		}
+		if vm.MemoryStartupBytes != 8*1024*1024*1024 {
+			t.Errorf("MemoryStartupBytes=%d, want 8GiB", vm.MemoryStartupBytes)
+		}
+	})
+	t.Run("dynamic (DynamicMemoryEnabled=true)", func(t *testing.T) {
+		vm := &api.Vm{}
+		applyMemoryToVm(vm, &hyperv.Msvm_MemorySettingData{
+			VirtualQuantity: 2048, DynamicMemoryEnabled: true, Reservation: 1024, Limit: 4096,
+		})
+		if !vm.DynamicMemory {
+			t.Error("DynamicMemory は true であるべき")
+		}
+		if vm.StaticMemory {
+			t.Error("StaticMemory は false であるべき")
+		}
+		if vm.MemoryMinimumBytes != 1024*1024*1024 {
+			t.Errorf("MemoryMinimumBytes=%d, want 1GiB", vm.MemoryMinimumBytes)
+		}
+		if vm.MemoryMaximumBytes != 4*1024*1024*1024 {
+			t.Errorf("MemoryMaximumBytes=%d, want 4GiB", vm.MemoryMaximumBytes)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

実運用移行検証 (`HYPERV_USE_WSMAN=1` を実クラスタに対し `terraform plan`) で発見した go-wsman `GetVm` の3件の読み取りバグを修正。

- `DynamicMemory`/`StaticMemory` が常に false のゼロ値のままで、resource read が「Either dynamic or static must be selected」で実機の全 VM で失敗していた。`GetMemorySettings` を追加取得し `applyMemoryToVm` で合成。
- `ProcessorCount` が常に 0 のままで毎回 drift (0→実値) していた。`GetProcessorSettings` を追加取得。
- `HighMmioGapSize`/`LowMmioGapSize` は CIM 上 MB 単位だが `api.Vm` (PS版 `Get-VM` 由来) は byte 単位のため変換漏れがあり毎回 drift (512→536870912 等) していた。`mbToBytesU64` を追加。

## 検証

実クラスタ (homelab k8s-cp-01/worker-01/02、いずれも Gen1) に対する `terraform plan -parallelism=1` で、修正前は上記3種のフィールドで drift が出ていたが修正後は解消を確認。`terraform apply` は未実施 (read-only の plan のみで検証)。

## 既知の残 drift (この PR のスコープ外)

- `automatic_critical_error_action_timeout` (0→30): CIM の Duration/interval 文字列パースが必要な別種の課題のため #102 で追跡。
- `checkpoint_type`/`turn_off_on_destroy` の diff: Optional+Default スキーマフィールドの初回反映で、go-wsman read とは無関係 (初回 apply で解消する一時的な diff)。

## 別途発見・Issue化

`terraform plan` の既定並行数 (parallelism=10) で go-wsman 経由の複数リクエストが HTTP 401 になる問題を発見 (`-parallelism=1` なら成功)。go-wsman 側の課題のため go-wsman#117 で追跡。本番運用では `-parallelism=1` が必要な状態。

## Test plan

- [x] `go build ./...` / `go vet ./...` green
- [x] `go test ./... -count=1` (unit) green、`TestVmFromSettingData` の期待値を単位変換後の正しい byte 値に更新、`TestMbToBytesU64`/`TestApplyMemoryToVm` を新規追加
- [x] 実クラスタへの `terraform plan -parallelism=1` で drift 解消を確認 (apply は未実施)