### PR TITLE
fix: go-wsmanクライアントをプール化しNTLM並行401を解消 (#117)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb
+	github.com/r4sd/go-wsman v0.0.0-20260726171130-4765e3e6b472
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803 h1:Rtr7oZyhy8SfaFQki
 github.com/r4sd/go-wsman v0.0.0-20260726093049-b67e245c5803/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb h1:FpajNGrbmcwdFYl7Mt5aTYRU1gYpotHa3C8lYDiXWZg=
 github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
+github.com/r4sd/go-wsman v0.0.0-20260726171130-4765e3e6b472 h1:3JnZUWK2t72im0+Gf/UnU0hhzLU/QU6hYX3mvUYFRvU=
+github.com/r4sd/go-wsman v0.0.0-20260726171130-4765e3e6b472/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -289,6 +289,16 @@ func getHypervProvider(config *Config) (hypervProvider *api.Provider, err error)
 //   - provider 設定 insecure=false (デフォルト): 証明書検証あり
 //   - provider 設定 insecure=true: WithInsecureSkipVerify() で検証スキップ
 //     (homelab のように自己署名証明書を使う環境向け)
+// wsmanClientPoolSize は go-wsman クライアントの並行接続プールサイズ。
+//
+// NTLM はコネクション単位でハンドシェイクの状態を保持するプロトコルのため、単一の
+// コネクションプールを複数 goroutine で共有すると、あるリクエストのハンドシェイク中に
+// 別のリクエストが割り込み 401 になりうる (実機で Terraform 既定 parallelism=10 の並行
+// GetVhd 7 件が全滅、-parallelism=1 なら成功、と確認済み。go-wsman#117)。
+// Terraform の既定 `-parallelism` (10) に合わせておけば、明示指定なしの通常運用でも
+// プールが枯渇せず干渉が起きない。
+const wsmanClientPoolSize = 10
+
 func newWsmanClient(config *Config) (*gowsman.Client, error) {
 	scheme := "http"
 	if config.HTTPS {
@@ -304,5 +314,5 @@ func newWsmanClient(config *Config) (*gowsman.Client, error) {
 		opts = append(opts, gowsmanproto.WithInsecureSkipVerify())
 	}
 
-	return gowsman.NewClient(endpoint, opts...)
+	return gowsman.NewPooledClient(wsmanClientPoolSize, endpoint, opts...)
 }


### PR DESCRIPTION
## Summary

Terraform 既定の `-parallelism` (10) で go-wsman 経由のリクエストが並行実行されると NTLM 認証が 401 になる問題 (go-wsman#117 で根治実装済み: `wsman.NewPooledClient`/`hyperv.NewPooledClient`) に対応。`newWsmanClient` を `gowsman.NewPooledClient(10, ...)` に切り替え。プールサイズ 10 は Terraform の既定 parallelism に合わせた値。

## 検証

実クラスタ (homelab k8s-cp-01/worker-01/02) に対し**既定 parallelism (flag指定なし、10)** で `terraform plan` を実行し、401 が発生しないことを確認。修正前は同条件で全 VHD read が 401 で失敗していた。

残る diff (`automatic_critical_error_action_timeout` 等3件) は #102 で追跡中の既知の課題で変化なし。`apply` は未実施 (read-only の plan のみで検証)。

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./... -count=1` green
- [x] 実クラスタへの既定 parallelism `terraform plan` で 401 解消を確認 (apply 未実施)