### PR TITLE
fix: GetVm が AutomaticCriticalErrorActionTimeout を未対応のため plan が毎回 drift する問題を修正 (#102)

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -5,11 +5,65 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/r4sd/go-wsman/hyperv"
 	"github.com/taliesins/terraform-provider-hyperv/api"
 )
+
+// intervalISO8601Pattern は WS-Man の GET/PULL レスポンスが返す datetime(interval) 型の実機書式に
+// マッチする。実機確認 (2026-07-27、k8s-cp-01 read): "P0DT0H30M0S"。ISO 8601 duration 形式
+// (PnDTnHnMnS)。WS-Management が CIM datetime interval をレスポンス側で xs:duration に
+// マッピングするための wire format と考えられる。
+//
+// 書き込み方向 (embedded instance) は未実装 (#102 参照)。CIM-XML の TYPE 属性が Go の
+// string kind から一律 "string" と推論され (go-wsman hyperv/embedded.go の cimTypeName)、
+// この MOF 上 datetime 型のプロパティを "string" 型として送ると DefineSystem が
+// ErrorCode=32768 (Exception) で失敗することを実機確認済み。ISO 8601 / CIM ネイティブ形式
+// (ddddddddHHMMSS.mmmmmm:000) いずれの文字列内容でも同一エラーになるため、原因は文字列書式
+// ではなく TYPE 属性側。go-wsman 側に datetime 型を明示できる仕組み (cim タグ拡張等) が要る。
+var intervalISO8601Pattern = regexp.MustCompile(`^P(\d+)DT(\d+)H(\d+)M(\d+)S$`)
+
+// parseIntervalMinutes は datetime(interval) 型の文字列 (ISO 8601 形式、上記パターン参照) を
+// 分単位の int32 に変換する。AutomaticCriticalErrorActionTimeout は Hyper-V が分単位に丸める
+// 仕様 (MOF 記載) のため秒は通常 0 だが、端数があれば切り上げる (防御的)。空文字は 0 (未設定)
+// として扱う。
+func parseIntervalMinutes(s string) (int32, error) {
+	if s == "" {
+		return 0, nil
+	}
+	m := intervalISO8601Pattern.FindStringSubmatch(s)
+	if m == nil {
+		return 0, fmt.Errorf("parseIntervalMinutes: unexpected format %q (want ISO 8601 PnDTnHnMnS)", s)
+	}
+	days, err1 := strconv.ParseInt(m[1], 10, 64)
+	hours, err2 := strconv.ParseInt(m[2], 10, 64)
+	minutes, err3 := strconv.ParseInt(m[3], 10, 64)
+	seconds, err4 := strconv.ParseInt(m[4], 10, 64)
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return 0, fmt.Errorf("parseIntervalMinutes: failed to parse numeric fields in %q", s)
+	}
+	total := days*24*60 + hours*60 + minutes
+	if seconds > 0 {
+		total++
+	}
+	return clampInt32FromInt64(total), nil
+}
+
+// clampInt32FromInt64 は int64 を int32 に安全に縮小する (上限/下限超過はクランプ)。
+// 直接 int32(v) すると CodeQL が上限チェックなしの縮小変換 (high) として検出するため
+// (clampUint32/clampInt32 と同じ理由)。
+func clampInt32FromInt64(v int64) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
 
 // VmExists は go-wsman 経由で VM (表示名) の存在を確認する。
 //
@@ -50,6 +104,12 @@ func (c *ClientConfig) GetVm(ctx context.Context, name string) (api.Vm, error) {
 		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
 	}
 	vm := vmFromSettingData(name, sd)
+
+	timeout, err := parseIntervalMinutes(sd.AutomaticCriticalErrorActionTimeout)
+	if err != nil {
+		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
+	}
+	vm.AutomaticCriticalErrorActionTimeout = timeout
 
 	mem, err := c.WsmanClient.GetMemorySettings(ctx, cs.Name)
 	if err != nil {
@@ -127,12 +187,13 @@ func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) ap
 		SmartPagingFilePath:     sd.SwapFileDataRoot,
 
 		// 以下は本メソッドでは未設定 (ゼロ値):
-		//   - Memory (MemoryStartupBytes/Min/Max, DynamicMemory, StaticMemory) / ProcessorCount:
-		//     呼び出し側の GetVm が Msvm_MemorySettingData / Msvm_ProcessorSettingData を
-		//     別途取得し合成する (applyMemoryToVm / clampInt64(proc.VirtualQuantity))。
-		//   - AutomaticStartDelay / AutomaticCriticalErrorActionTimeout: CIM の
-		//     Duration/interval 文字列パースが必要。実機が返す実書式に合わせるため
-		//     acc test (Phase D) で実データ確認後に実装する。
+		//   - Memory (MemoryStartupBytes/Min/Max, DynamicMemory, StaticMemory) / ProcessorCount /
+		//     AutomaticCriticalErrorActionTimeout: 呼び出し側の GetVm が
+		//     Msvm_MemorySettingData / Msvm_ProcessorSettingData を別途取得して合成、
+		//     AutomaticCriticalErrorActionTimeout は sd.AutomaticCriticalErrorActionTimeout
+		//     (CIM datetime/interval 文字列) を parseIntervalMinutes で分に変換する。
+		//   - AutomaticStartDelay: 同じく CIM Duration 文字列パースが必要だが go-wsman の
+		//     CIM 構造体に未マッピング (#102 のスコープ外、homelab config も未使用で実害なし)。
 		//   - CheckpointType / AutomaticCheckpointsEnabled: v2.1 (#46) に延期。
 	}
 }
@@ -218,9 +279,9 @@ func needsTurnOff(state uint16) bool {
 // 自動 NIC/DVD は付かない想定)。parity 担保のため自動生成 NIC は防御的に削除する
 // (実際に生成されるかは Phase D 実機で確認)。
 //
-// 未適用 (GetVm と同じ理由で将来対応):
-//   - automaticStartDelay / automaticCriticalErrorActionTimeout: CIM Duration 文字列の
-//     エンコードが要る。実機書式を Phase D で確認後に対応。
+// 未適用:
+//   - automaticStartDelay: CIM Duration 文字列のエンコードが要るが go-wsman の CIM 構造体に
+//     未マッピング (#102 のスコープ外、homelab config も未使用で実害なし)。
 //   - checkpointType / automaticCheckpointsEnabled: v2.1 (#46) に延期。
 func (c *ClientConfig) CreateVm(
 	ctx context.Context,
@@ -325,8 +386,7 @@ func (c *ClientConfig) CreateVm(
 // CIM の ModifySystemSettings はゼロ値フィールドを「変更なし」とみなすため、各フィールドは
 // 新しい値で上書きする (CreateVm と enum/メモリ変換ロジックを共有)。
 //
-// 未適用 (GetVm/CreateVm と同じ理由): automaticStartDelay /
-// automaticCriticalErrorActionTimeout (CIM Duration、Phase D) / checkpointType /
+// 未適用: automaticStartDelay (CreateVm と同じ理由、#102 スコープ外) / checkpointType /
 // automaticCheckpointsEnabled (v2.1)。
 func (c *ClientConfig) UpdateVm(
 	ctx context.Context,
@@ -489,6 +549,9 @@ func vmSettingDataForCreate(
 // enum は provider 整数値 = CIM 値 (GetVm/CreateVm と同前提)。空文字のパスと未指定のゼロ値は
 // marshalEmbeddedInstance が省略するため、Update (ModifySystemSettings) では「未指定=変更なし」
 // になる (CIM SettingData の慣習)。InstanceID 等の既存値は呼び出し側が保持する。
+//
+// AutomaticCriticalErrorActionTimeout の書き込みは未実装 (#102、intervalISO8601Pattern の
+// コメント参照)。
 func applyVmLevelSettings(
 	sd *hyperv.Msvm_VirtualSystemSettingData,
 	criticalErrorAction api.CriticalErrorAction,

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -367,6 +367,36 @@ func TestApplyMemoryToVm(t *testing.T) {
 	})
 }
 
+// TestParseIntervalMinutes は WS-Man の datetime(interval) 生文字列 (ISO 8601 duration 形式、
+// 実機確認 2026-07-27: "P0DT0H30M0S") を分単位に変換することを検証する。
+// MOF ドキュメント記載の COM/WMI ネイティブ形式 (ddddddddHHMMSS.mmmmmm:000) とは異なる実機実測値。
+func TestParseIntervalMinutes(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int32
+		wantErr bool
+	}{
+		{"実機確認値 30分", "P0DT0H30M0S", 30, false},
+		{"0分 (即座に電源オフ)", "P0DT0H0M0S", 0, false},
+		{"空文字はゼロ扱い", "", 0, false},
+		{"時+分の合算 (1時間30分=90分)", "P0DT1H30M0S", 90, false},
+		{"日+時+分の合算 (1日2時間3分=1563分)", "P1DT2H3M0S", 1*24*60 + 2*60 + 3, false},
+		{"不正な書式はエラー", "not-a-duration", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseIntervalMinutes(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseIntervalMinutes(%q): err=%v, wantErr=%v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseIntervalMinutes(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestVmSettingDataForCreate は CreateVm パラメータ → Msvm_VirtualSystemSettingData
 // マッピング (GetVm の vmFromSettingData の逆) を検証する。
 func TestVmSettingDataForCreate(t *testing.T) {

--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -289,6 +289,7 @@ func getHypervProvider(config *Config) (hypervProvider *api.Provider, err error)
 //   - provider 設定 insecure=false (デフォルト): 証明書検証あり
 //   - provider 設定 insecure=true: WithInsecureSkipVerify() で検証スキップ
 //     (homelab のように自己署名証明書を使う環境向け)
+//
 // wsmanClientPoolSize は go-wsman クライアントの並行接続プールサイズ。
 //
 // NTLM はコネクション単位でハンドシェイクの状態を保持するプロトコルのため、単一の

--- a/internal/provider/vm_crud_integration_test.go
+++ b/internal/provider/vm_crud_integration_test.go
@@ -55,7 +55,7 @@ func TestRealHostVmCrudWsman(t *testing.T) {
 		"",                            // path (既定の場所)
 		2,                             // generation (Gen2)
 		api.CriticalErrorAction_Pause, // automaticCriticalErrorAction
-		0,                             // automaticCriticalErrorActionTimeout
+		0,                             // automaticCriticalErrorActionTimeout (書き込み未実装 #102、CIM 既定 30 分になる)
 		api.StartAction_Nothing,       // automaticStartAction
 		0,                             // automaticStartDelay
 		api.StopAction_Save,           // automaticStopAction
@@ -102,14 +102,19 @@ func TestRealHostVmCrudWsman(t *testing.T) {
 	if vm.AutomaticStartAction != api.StartAction_Nothing {
 		t.Errorf("AutomaticStartAction = %v, want Nothing", vm.AutomaticStartAction)
 	}
-	t.Logf("GetVm OK: gen=%d notes=%q start=%v stop=%v crit=%v",
-		vm.Generation, vm.Notes, vm.AutomaticStartAction, vm.AutomaticStopAction, vm.AutomaticCriticalErrorAction)
+	// 書き込みは未実装 (#102) のため CIM 既定値の 30 分になる。GetVm の read パースが
+	// 実機の生値 ("P0DT0H30M0S") を正しく解釈できていることの回帰ガード。
+	if vm.AutomaticCriticalErrorActionTimeout != 30 {
+		t.Errorf("AutomaticCriticalErrorActionTimeout = %d, want 30 (CIM 既定値、#102 read parse)", vm.AutomaticCriticalErrorActionTimeout)
+	}
+	t.Logf("GetVm OK: gen=%d notes=%q start=%v stop=%v crit=%v timeout=%d",
+		vm.Generation, vm.Notes, vm.AutomaticStartAction, vm.AutomaticStopAction, vm.AutomaticCriticalErrorAction, vm.AutomaticCriticalErrorActionTimeout)
 
 	// --- 4. Update → VM-level / Memory / Processor を変更 ---
 	if err := cc.UpdateVm(ctx, name,
 		api.CriticalErrorAction_Pause, // (None=0 はゼロ値省略で変更不可のため Pause 維持)
-		0,
-		api.StartAction_Start, // 変更: Nothing → Start
+		0,                             // automaticCriticalErrorActionTimeout (書き込み未実装 #102)
+		api.StartAction_Start,         // 変更: Nothing → Start
 		0,
 		api.StopAction_ShutDown, // 変更: Save → ShutDown
 		api.CheckpointType_Production,
@@ -145,8 +150,11 @@ func TestRealHostVmCrudWsman(t *testing.T) {
 	if vm2.LockOnDisconnect != api.OnOffState_On {
 		t.Errorf("LockOnDisconnect after Update = %v, want On", vm2.LockOnDisconnect)
 	}
-	t.Logf("UpdateVm OK: notes=%q start=%v stop=%v lock=%v",
-		vm2.Notes, vm2.AutomaticStartAction, vm2.AutomaticStopAction, vm2.LockOnDisconnect)
+	if vm2.AutomaticCriticalErrorActionTimeout != 30 {
+		t.Errorf("AutomaticCriticalErrorActionTimeout after Update = %d, want 30 (書き込み未実装のため不変、#102)", vm2.AutomaticCriticalErrorActionTimeout)
+	}
+	t.Logf("UpdateVm OK: notes=%q start=%v stop=%v lock=%v timeout=%d",
+		vm2.Notes, vm2.AutomaticStartAction, vm2.AutomaticStopAction, vm2.LockOnDisconnect, vm2.AutomaticCriticalErrorActionTimeout)
 
 	// --- 6. Delete → Exists false ---
 	if err := cc.DeleteVm(ctx, name); err != nil {


### PR DESCRIPTION
## 概要

WS-Man 経路 (`HYPERV_USE_WSMAN=1`) の `GetVm` が `AutomaticCriticalErrorActionTimeout`
を読み取らず常に 0 を返していたため、schema default (30分) との差分で `terraform plan`
が毎回 drift していた問題を修正。

## 変更内容

- `parseIntervalMinutes`: WS-Man の GET/PULL レスポンスが返す datetime(interval) 型の
  ISO 8601 duration 文字列 (実機確認 "P0DT0H30M0S") を分単位の int32 に変換
- `GetVm` に組み込み、`vm.AutomaticCriticalErrorActionTimeout` を正しく設定

## 書き込み方向はスコープ外

`DefineSystem`/`ModifySystemSettings` の embedded instance に当該フィールドを書き込むと、
ISO 8601 形式・MOF 記載の CIM ネイティブ形式のいずれでも `ErrorCode=32768` (Exception) で
失敗することを実機確認した。文字列書式ではなく CIM-XML の `TYPE` 属性の推論ミス
(go-wsman の `cimTypeName` が Go の `string` kind から一律 `"string"` と決め打ちしており、
MOF 上 `datetime` 型のプロパティに誤った型を送っている) が原因と特定済み。
go-wsman 側のマーシャリング機構拡張が必要な、より大きい変更のため
r4sd/go-wsman#119 に切り出した。

## 検証

- `go build ./... && go vet ./... && go test ./... -count=1` green
- 実機 acc test `TestRealHostVmCrudWsman` PASS (`timeout=30` = Hyper-V 既定値の読み取りを確認)
- homelab 本番 config で `terraform plan` を実行し、当該フィールドの diff が消えたことを確認
  (残る diff は `checkpoint_type` [#106、別件・要修正] と `turn_off_on_destroy` [スキーマのみ・実害なし] のみ)

## 副産物

調査中に発見した別バグを Issue 化 (本 PR のスコープ外):
- #105 (既存、highMmioGapSize/lowMmioGapSize の単位変換漏れ)
- #106 (新規、`checkpoint_type` が WS-Man 経路で恒常 drift する)

Closes #102