### PR TITLE
fix: GetVm が CheckpointType を未設定のため plan が恒常 drift する問題を修正

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -185,6 +185,9 @@ func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) ap
 		LowMemoryMappedIoSpace:  clampUint32(mbToBytesU64(sd.LowMmioGapSize)),
 		SnapshotFileLocation:    sd.SnapshotDataRoot,
 		SmartPagingFilePath:     sd.SwapFileDataRoot,
+		// UserSnapshotType(CIM) は Microsoft.HyperV.PowerShell.CheckpointType と数値が
+		// 一致する定義のため直接変換 (#106、MOF 一次資料確認済み)。write 側は #46 に延期。
+		CheckpointType: api.CheckpointType(sd.UserSnapshotType),
 
 		// 以下は本メソッドでは未設定 (ゼロ値):
 		//   - Memory (MemoryStartupBytes/Min/Max, DynamicMemory, StaticMemory) / ProcessorCount /
@@ -194,7 +197,7 @@ func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) ap
 		//     (CIM datetime/interval 文字列) を parseIntervalMinutes で分に変換する。
 		//   - AutomaticStartDelay: 同じく CIM Duration 文字列パースが必要だが go-wsman の
 		//     CIM 構造体に未マッピング (#102 のスコープ外、homelab config も未使用で実害なし)。
-		//   - CheckpointType / AutomaticCheckpointsEnabled: v2.1 (#46) に延期。
+		//   - AutomaticCheckpointsEnabled: v2.1 (#46) に延期。
 	}
 }
 

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -107,6 +107,7 @@ func TestVmFromSettingData(t *testing.T) {
 		ConfigurationDataRoot:        `C:\vms\test`,
 		SnapshotDataRoot:             `C:\vms\snap`,
 		SwapFileDataRoot:             `C:\vms\swap`,
+		UserSnapshotType:             hyperv.UserSnapshotTypeProductionNoFallback,
 	}
 
 	got := vmFromSettingData("test-vm", sd)
@@ -150,6 +151,10 @@ func TestVmFromSettingData(t *testing.T) {
 	}
 	if got.SmartPagingFilePath != `C:\vms\swap` {
 		t.Errorf("SmartPagingFilePath = %q", got.SmartPagingFilePath)
+	}
+	// UserSnapshotType(CIM) → CheckpointType(api) は値が一致する定義のため直接変換 (#106)。
+	if got.CheckpointType != api.CheckpointType_ProductionOnly {
+		t.Errorf("CheckpointType = %v, want ProductionOnly", got.CheckpointType)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d
-	github.com/r4sd/go-wsman v0.0.0-20260726171130-4765e3e6b472
+	github.com/r4sd/go-wsman v0.0.0-20260727122908-95968737f88b
 	github.com/segmentio/ksuid v1.0.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb h1:FpajNGrbmcwdFYl7M
 github.com/r4sd/go-wsman v0.0.0-20260726153702-4468ea4c22cb/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/r4sd/go-wsman v0.0.0-20260726171130-4765e3e6b472 h1:3JnZUWK2t72im0+Gf/UnU0hhzLU/QU6hYX3mvUYFRvU=
 github.com/r4sd/go-wsman v0.0.0-20260726171130-4765e3e6b472/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
+github.com/r4sd/go-wsman v0.0.0-20260727122908-95968737f88b h1:OLZ+vCr3CU+mKDBBem4pem5jkHHGWyJnUGg17SQPT+4=
+github.com/r4sd/go-wsman v0.0.0-20260727122908-95968737f88b/go.mod h1:tCo8ynbuQiXKsLDkjxYO8KlSofmFxLrDdhl8iLy3pwY=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=


### PR DESCRIPTION
## 概要

Closes #106

WS-Man 経路の `vmFromSettingData` は `CheckpointType` を設定しておらず、常に Go
ゼロ値になっていた。schema の Default("Production") に対し read が空文字列を
`Set` するため、config が `checkpoint_type` を明示しない場合 `terraform plan` が
毎回 drift 検出し(一度も収束しない)、`hasChangesThatRequireVmToBeOff` 経由で
**apply のたびに稼働中の VM を強制シャットダウンする**安全上のブロッカーだった。

## 一次資料確認

- `CheckpointType` という名前の CIM プロパティは存在しない。対応するのは
  `Msvm_VirtualSystemSettingData.UserSnapshotType` (uint16、MOF 確認済み)。
- 値は 2=Disable / 3=ProductionFallbackToTest / 4=ProductionNoFallback / 5=Test。
  既存の `api.CheckpointType` (Disabled=2/Production=3/ProductionOnly=4/Standard=5)
  と数値が完全一致(意味論も対応: Production=フォールバック付きVSS、
  ProductionOnly=フォールバックなし、Standard=メモリ含む test 型)。

## 変更内容

- go-wsman に `UserSnapshotType` primitive を追加(別PR、r4sd/go-wsman#121、マージ済み)
- go.mod を go-wsman `9596873` へ bump
- `vmFromSettingData` で `CheckpointType: api.CheckpointType(sd.UserSnapshotType)` を設定
- 純関数ユニットテストにアサーション追加(TDD: RED→GREEN確認済み)

## スコープ外

- write 側 (`checkpoint_type` の変更を WS-Man 経由で適用) は既存どおり #46 に延期。
  `CreateVm`/`UpdateVm` の `checkpointType` 引数は本 PR でも未適用のまま。
- 実機検証中に無関係な stale test を発見、別 Issue 化(#108)。

## Test plan

- [x] `go test ./... -count=1` 全 green
- [x] `go vet ./... && go build ./...` green
- [x] 実機 acc test (`TestRealHostStrictReadNoPS`, k8s-worker-01 Gen1): 本題の Read 経路
      アサーション(PS呼び出し0件)は合格。negative control 1件は #108(無関係な stale test)で FAIL