### PR TITLE
docs: 「敵対的レビュー」の呼称を「批判的レビュー」に統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ framework。Slice A(vm_processor write)を型として蒸留(2026-07-19)。**新
 ③ provider shadow(read 変換 / write 逆変換 + ガード)
 ④ unit test(純関数: 変換・ガード・境界)
 ⑤ 実機 acc test(//go:build integration。mutation は使い捨て VM を CreateVm→t.Cleanup で削除)
-⑥ Fable 敵対レビュー → 致命指摘を反映 → 実機で再検証
+⑥ Fable 批判的レビュー → 致命指摘を反映 → 実機で再検証
 ⑦ PR → CI 全 green
 ```
 
@@ -51,7 +51,7 @@ framework。Slice A(vm_processor write)を型として蒸留(2026-07-19)。**新
 - [ ] **TDD 先行**: RED を確認してから実装(`feedback_tdd_first_default` (memory))。
 - [ ] コメントは **WHY**(単位・契約・非自明な制約)。コードを言い換える WHAT は書かない。
 - [ ] 実機 acc test を **1 回は実行して GREEN を確認**(CI 非実行のためログを PR に残す)。
-- [ ] **Fable 敵対レビュー**を実施し、致命指摘は merge 前に反映。**プロンプトは過度な手順書きをせず、判定(CONFIRMED/REFUTED等)と結論を求める形にする**(Fable 系モデルは非手続き的な指示の方が出力品質が高い。手順は Claude 側=このパイプラインの実行者が担い、Fable には「何を検証するか」だけ渡す)。
+- [ ] **Fable 批判的レビュー**を実施し、致命指摘は merge 前に反映。**プロンプトは過度な手順書きをせず、判定(CONFIRMED/REFUTED等)と結論を求める形にする**(Fable 系モデルは非手続き的な指示の方が出力品質が高い。手順は Claude 側=このパイプラインの実行者が担い、Fable には「何を検証するか」だけ渡す)。
 
 ## 4. この型が固めた shadow 特有の設計ルール(再発防止)
 

--- a/api/hyperv-wsman/vm_firmware_bootorder_test.go
+++ b/api/hyperv-wsman/vm_firmware_bootorder_test.go
@@ -215,7 +215,7 @@ func TestResolveBootSourceRefs_Empty(t *testing.T) {
 // TestResolveBootSourceRefs_AmbiguousNetworkAdapterName は同名 NIC が複数存在する場合
 // (Hyper-V の既定名 "Network Adapter" 等)、Name のみの一致で決め打たず明示エラーになることを
 // 検証する。Name だけで先頭一致させると違う NIC の InstanceID を誤って書き込む危険がある
-// (Fable 敵対レビュー指摘、silent corruption)。
+// (Fable 批判的レビュー指摘、silent corruption)。
 func TestResolveBootSourceRefs_AmbiguousNetworkAdapterName(t *testing.T) {
 	nicRefs := []networkAdapterRef{
 		{portInstanceID: "nic-1", adapter: api.VmNetworkAdapter{Name: "Network Adapter", SwitchName: "Internet-sw"}},


### PR DESCRIPTION
## 概要

DoD の Fable レビューステップ名とコード内コメントの「敵対的レビュー」を
「批判的レビュー」に変更(呼称のみ、挙動・レビュー内容に変更なし)。

## Test plan

- [x] `go build ./... && go vet ./...` green(ドキュメント/コメントのみの変更)