### PR TITLE
fix: checkpoint_type の未知値・書き込み黙殺を fail-loud にする

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -103,7 +103,10 @@ func (c *ClientConfig) GetVm(ctx context.Context, name string) (api.Vm, error) {
 	if err != nil {
 		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
 	}
-	vm := vmFromSettingData(name, sd)
+	vm, err := vmFromSettingData(name, sd)
+	if err != nil {
+		return api.Vm{}, fmt.Errorf("hyperv-wsman: GetVm %q: %w", name, err)
+	}
 
 	timeout, err := parseIntervalMinutes(sd.AutomaticCriticalErrorActionTimeout)
 	if err != nil {
@@ -167,7 +170,11 @@ func mbToBytesU64(mb uint64) uint64 {
 // enum (CriticalErrorAction/StartAction/StopAction) は provider 側の整数値が CIM 値と
 // 一致するよう定義されているため直接変換する (None=0/Pause=1、Nothing=2/Start=4 等)。
 // uint16→int は拡大変換のため安全。
-func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) api.Vm {
+func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) (api.Vm, error) {
+	checkpointType, err := checkpointTypeFromUserSnapshotType(sd.UserSnapshotType)
+	if err != nil {
+		return api.Vm{}, fmt.Errorf("checkpoint_type: %w", err)
+	}
 	return api.Vm{
 		Name:                         name,
 		Path:                         sd.ConfigurationDataRoot,
@@ -187,7 +194,7 @@ func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) ap
 		SmartPagingFilePath:     sd.SwapFileDataRoot,
 		// UserSnapshotType(CIM) は Microsoft.HyperV.PowerShell.CheckpointType と数値が
 		// 一致する定義のため直接変換 (#106、MOF 一次資料確認済み)。write 側は #46 に延期。
-		CheckpointType: api.CheckpointType(sd.UserSnapshotType),
+		CheckpointType: checkpointType,
 
 		// 以下は本メソッドでは未設定 (ゼロ値):
 		//   - Memory (MemoryStartupBytes/Min/Max, DynamicMemory, StaticMemory) / ProcessorCount /
@@ -198,7 +205,44 @@ func vmFromSettingData(name string, sd *hyperv.Msvm_VirtualSystemSettingData) ap
 		//   - AutomaticStartDelay: 同じく CIM Duration 文字列パースが必要だが go-wsman の
 		//     CIM 構造体に未マッピング (#102 のスコープ外、homelab config も未使用で実害なし)。
 		//   - AutomaticCheckpointsEnabled: v2.1 (#46) に延期。
+	}, nil
+}
+
+// validateCheckpointFieldsUnchanged は checkpointType/automaticCheckpointsEnabled が現在値と
+// 一致するか検証する。WS-Man 経由の変更適用は未実装 (#46) のため、黙って無視すると
+// 「read→drift→shutdown→書き込みは no-op→再起動後も drift」のループになる
+// (Fable 批判的レビュー指摘)。UpdateVm から呼ぶ。
+func validateCheckpointFieldsUnchanged(
+	wantCheckpointType api.CheckpointType,
+	wantAutomaticCheckpointsEnabled bool,
+	cur *hyperv.Msvm_VirtualSystemSettingData,
+) error {
+	curCheckpointType, err := checkpointTypeFromUserSnapshotType(cur.UserSnapshotType)
+	if err != nil {
+		return fmt.Errorf("checkpoint_type: %w", err)
 	}
+	if wantCheckpointType != curCheckpointType {
+		return fmt.Errorf("checkpoint_type の変更 (%s→%s) は WS-Man 経路で未実装 (#46)。HYPERV_USE_WSMAN=0 (PS 経路) を使うこと",
+			curCheckpointType, wantCheckpointType)
+	}
+	if wantAutomaticCheckpointsEnabled != cur.AutomaticSnapshotsEnabled {
+		return fmt.Errorf("automatic_checkpoints_enabled の変更 (%t→%t) は WS-Man 経路で未実装 (#46)。HYPERV_USE_WSMAN=0 (PS 経路) を使うこと",
+			cur.AutomaticSnapshotsEnabled, wantAutomaticCheckpointsEnabled)
+	}
+	return nil
+}
+
+// checkpointTypeFromUserSnapshotType は CIM の UserSnapshotType を api.CheckpointType に
+// 変換する。既知の値 (2-5) 以外は CIM 応答異常 (フィールド欠落によるゼロ値・未知の列挙値) として
+// エラーを返す。ここを黙って通すと api.CheckpointType.String() が空文字列を返し、#106 の
+// 恒常 drift (schema Default との不一致で毎 plan diff → apply 毎に VM 強制シャットダウン) が
+// 無音で再発するため fail-loud にする (Fable 批判的レビュー指摘)。
+func checkpointTypeFromUserSnapshotType(v uint16) (api.CheckpointType, error) {
+	ct := api.CheckpointType(v)
+	if _, ok := api.CheckpointType_name[ct]; !ok {
+		return 0, fmt.Errorf("未知の UserSnapshotType 値 %d (既知範囲は 2-5)", v)
+	}
+	return ct, nil
 }
 
 // vmGenerationFromSubType は VirtualSystemSubType を Generation 番号に変換する。
@@ -389,8 +433,11 @@ func (c *ClientConfig) CreateVm(
 // CIM の ModifySystemSettings はゼロ値フィールドを「変更なし」とみなすため、各フィールドは
 // 新しい値で上書きする (CreateVm と enum/メモリ変換ロジックを共有)。
 //
-// 未適用: automaticStartDelay (CreateVm と同じ理由、#102 スコープ外) / checkpointType /
-// automaticCheckpointsEnabled (v2.1)。
+// 未適用: automaticStartDelay (CreateVm と同じ理由、#102 スコープ外)。checkpointType /
+// automaticCheckpointsEnabled は書き込み自体が v2.1 (#46) まで未実装だが、変更要求を
+// 黙って無視すると「read→drift→shutdown→書き込みは no-op」のループになるため、
+// 現在値との不一致を検知したら明示エラーで PS 経路への委譲を促す
+// (validateCheckpointFieldsUnchanged、Fable 批判的レビュー指摘)。
 func (c *ClientConfig) UpdateVm(
 	ctx context.Context,
 	name string,
@@ -428,6 +475,9 @@ func (c *ClientConfig) UpdateVm(
 	cur, err := c.WsmanClient.GetSystemSettingData(ctx, guid)
 	if err != nil {
 		return fmt.Errorf("hyperv-wsman: UpdateVm %q: get settings: %w", name, err)
+	}
+	if err := validateCheckpointFieldsUnchanged(checkpointType, automaticCheckpointsEnabled, cur); err != nil {
+		return fmt.Errorf("hyperv-wsman: UpdateVm %q: %w", name, err)
 	}
 	sd := &hyperv.Msvm_VirtualSystemSettingData{InstanceID: cur.InstanceID}
 	applyVmLevelSettings(sd, automaticCriticalErrorAction, automaticStartAction, automaticStopAction,

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -110,7 +110,10 @@ func TestVmFromSettingData(t *testing.T) {
 		UserSnapshotType:             hyperv.UserSnapshotTypeProductionNoFallback,
 	}
 
-	got := vmFromSettingData("test-vm", sd)
+	got, err := vmFromSettingData("test-vm", sd)
+	if err != nil {
+		t.Fatalf("vmFromSettingData: %v", err)
+	}
 
 	if got.Name != "test-vm" {
 		t.Errorf("Name = %q, want test-vm", got.Name)
@@ -155,6 +158,28 @@ func TestVmFromSettingData(t *testing.T) {
 	// UserSnapshotType(CIM) → CheckpointType(api) は値が一致する定義のため直接変換 (#106)。
 	if got.CheckpointType != api.CheckpointType_ProductionOnly {
 		t.Errorf("CheckpointType = %v, want ProductionOnly", got.CheckpointType)
+	}
+}
+
+// TestVmFromSettingData_InvalidUserSnapshotType は UserSnapshotType が既知の値
+// (2-5) 以外の場合に fail-loud でエラーになることを検証する。CIM 応答異常
+// (フィールド欠落によるゼロ値・想定外の列挙値) を、空文字列の checkpoint_type として
+// 静かに #106 型の drift を再発させないためのガード (Fable 批判的レビュー指摘)。
+func TestVmFromSettingData_InvalidUserSnapshotType(t *testing.T) {
+	tests := []struct {
+		name             string
+		userSnapshotType uint16
+	}{
+		{"ゼロ値(フィールド欠落)", 0},
+		{"既知範囲外(6)", 6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sd := &hyperv.Msvm_VirtualSystemSettingData{UserSnapshotType: tt.userSnapshotType}
+			if _, err := vmFromSettingData("test-vm", sd); err == nil {
+				t.Errorf("vmFromSettingData(UserSnapshotType=%d): エラーを期待したが nil", tt.userSnapshotType)
+			}
+		})
 	}
 }
 
@@ -514,4 +539,39 @@ func TestApplyVmLevelSettings(t *testing.T) {
 	if len(sd.Notes) != 2 || sd.Notes[0] != "n1" || sd.Notes[1] != "n2" {
 		t.Errorf("Notes=%v, want [n1 n2]", sd.Notes)
 	}
+}
+
+// TestValidateCheckpointFieldsUnchanged は checkpointType/automaticCheckpointsEnabled の
+// 変更要求を UpdateVm が黙って無視せず検知することを検証する (#106 Fable 批判的レビュー指摘、
+// write 側が #46 まで未実装のため、変更要求は fail-loud にする必要がある)。
+func TestValidateCheckpointFieldsUnchanged(t *testing.T) {
+	cur := &hyperv.Msvm_VirtualSystemSettingData{
+		UserSnapshotType:          hyperv.UserSnapshotTypeProductionFallbackToTest, // Production(3)
+		AutomaticSnapshotsEnabled: false,
+	}
+
+	t.Run("変更なしなら nil", func(t *testing.T) {
+		if err := validateCheckpointFieldsUnchanged(api.CheckpointType_Production, false, cur); err != nil {
+			t.Errorf("変更なしのはずがエラー: %v", err)
+		}
+	})
+
+	t.Run("checkpoint_type の変更要求はエラー", func(t *testing.T) {
+		if err := validateCheckpointFieldsUnchanged(api.CheckpointType_Disabled, false, cur); err == nil {
+			t.Error("checkpoint_type 変更要求はエラーになるべき (WS-Man write未実装)")
+		}
+	})
+
+	t.Run("automatic_checkpoints_enabled の変更要求はエラー", func(t *testing.T) {
+		if err := validateCheckpointFieldsUnchanged(api.CheckpointType_Production, true, cur); err == nil {
+			t.Error("automatic_checkpoints_enabled 変更要求はエラーになるべき (WS-Man write未実装)")
+		}
+	})
+
+	t.Run("現在値が不正(UserSnapshotType未知)ならエラー", func(t *testing.T) {
+		bad := &hyperv.Msvm_VirtualSystemSettingData{UserSnapshotType: 0}
+		if err := validateCheckpointFieldsUnchanged(api.CheckpointType_Production, false, bad); err == nil {
+			t.Error("不正な現在値はエラーになるべき")
+		}
+	})
 }


### PR DESCRIPTION
## 概要

#106 (checkpoint_type read 修正、PR#109) に対する Fable 批判的レビューで指摘された
残存リスク2件への対応。

## 変更内容

1. **未知値の fail-loud 化**: `UserSnapshotType` が既知の値 (2-5) 以外の場合、`GetVm` が
   黙って空文字列の `checkpoint_type` を返していた。go-wsman 側の将来的な regression
   (cim タグ typo 等) で #106 の恒常 drift が無音で再発しうるため、
   `checkpointTypeFromUserSnapshotType` で検証しエラーを返すようにした。
   (`vmFromSettingData` のシグネチャを `(api.Vm, error)` に変更)

2. **write 側の黙殺を fail-loud 化**: `UpdateVm` は `checkpointType`/
   `automaticCheckpointsEnabled` の変更要求を黙って無視していた(書き込み自体は #46 まで
   未実装)。config で明示的に値を変更すると「read→drift→shutdown→書き込みはno-op→
   再起動後もdrift」のループになるため、`validateCheckpointFieldsUnchanged` で現在値との
   不一致を検知したら明示エラー(PS経路への委譲を促すメッセージ付き)にした。

## Test plan

- [x] `go build ./... && go vet ./...` green
- [x] `go test ./... -count=1` 全 green
- [x] TDD: RED(シグネチャ不一致・未定義関数)→GREEN確認済み