### PR TITLE
fix: applyVmLevelSettings のHigh/LowMmioGapSize書き込みが単位変換されていない問題を修正

### DIFF
--- a/api/hyperv-wsman/vm.go
+++ b/api/hyperv-wsman/vm.go
@@ -165,6 +165,12 @@ func mbToBytesU64(mb uint64) uint64 {
 	return mb * 1024 * 1024
 }
 
+// bytesToMbU64 は byte 単位を CIM の MB 単位に変換する (mbToBytesU64 の逆変換、write 側)。
+// MB 境界に揃っていない値は切り捨てる (#105、CreateVm/UpdateVm の書き込みで必要)。
+func bytesToMbU64(bytes uint64) uint64 {
+	return bytes / (1024 * 1024)
+}
+
 // vmFromSettingData は Msvm_VirtualSystemSettingData を api.Vm にマッピングする (純関数)。
 //
 // enum (CriticalErrorAction/StartAction/StopAction) は provider 側の整数値が CIM 値と
@@ -621,8 +627,12 @@ func applyVmLevelSettings(
 	sd.AutomaticCriticalErrorAction = enumToUint16(int(criticalErrorAction))
 	sd.LockOnDisconnect = lockOnDisconnect == api.OnOffState_On
 	sd.GuestControlledCacheTypes = guestControlledCacheTypes
-	sd.HighMmioGapSize = highMmioGapSize
-	sd.LowMmioGapSize = uint64(lowMmioGapSize)
+	// HighMmioGapSize/LowMmioGapSize は CIM 上 MB 単位だが引数は api.Vm 由来の byte 単位
+	// (read 側 mbToBytesU64 の逆変換)。変換漏れのまま送信すると Hyper-V が
+	// ErrorCode=32773「無効な値」で CreateVm/UpdateVm を拒否する
+	// (#105、実機で新規VM作成が全滅する形で発覚、schema default値でも発火する)。
+	sd.HighMmioGapSize = bytesToMbU64(highMmioGapSize)
+	sd.LowMmioGapSize = bytesToMbU64(uint64(lowMmioGapSize))
 	if snapshotFileLocation != "" {
 		sd.SnapshotDataRoot = snapshotFileLocation
 	}

--- a/api/hyperv-wsman/vm_test.go
+++ b/api/hyperv-wsman/vm_test.go
@@ -357,6 +357,35 @@ func TestMbToBytesU64(t *testing.T) {
 	}
 }
 
+// TestBytesToMbU64 は mbToBytesU64 の逆変換 (write 側、#105) を検証する。
+func TestBytesToMbU64(t *testing.T) {
+	tests := []struct {
+		bytes uint64
+		want  uint64
+	}{
+		{0, 0},
+		{512 * 1024 * 1024, 512},
+		{128 * 1024 * 1024, 128},
+		{100, 0}, // MB 境界未満は切り捨て
+	}
+	for _, tt := range tests {
+		if got := bytesToMbU64(tt.bytes); got != tt.want {
+			t.Errorf("bytesToMbU64(%d)=%d, want %d", tt.bytes, got, tt.want)
+		}
+	}
+}
+
+// TestMbBytesRoundTrip は mbToBytesU64 (read) と bytesToMbU64 (write) が MB 境界に揃った値で
+// 厳密に往復することを検証する (DoD: 単位変換は round-trip test で固定する)。
+func TestMbBytesRoundTrip(t *testing.T) {
+	for _, mb := range []uint64{0, 1, 128, 512, 3584, 4096} {
+		bytes := mbToBytesU64(mb)
+		if got := bytesToMbU64(bytes); got != mb {
+			t.Errorf("round-trip: mb=%d → bytes=%d → mb=%d (want %d)", mb, bytes, got, mb)
+		}
+	}
+}
+
 // TestApplyMemoryToVm は Msvm_MemorySettingData → api.Vm のメモリ関連フィールドへのマッピングを
 // 検証する (実運用の実機検証で発見: このマッピングが無いと DynamicMemory/StaticMemory が両方
 // false のゼロ値のままになり、resource read が「Either dynamic or static must be selected」で
@@ -438,7 +467,7 @@ func TestVmSettingDataForCreate(t *testing.T) {
 	sd, err := vmSettingDataForCreate(
 		"vm1", cfgPath, 2,
 		api.CriticalErrorAction_Pause, api.StartAction_Start, api.StopAction_Save,
-		true, 512, api.OnOffState_On, 128,
+		true, 512*1024*1024, api.OnOffState_On, 128*1024*1024,
 		"note1\nnote2", pagePath, snapPath,
 	)
 	if err != nil {
@@ -511,7 +540,7 @@ func TestApplyVmLevelSettings(t *testing.T) {
 	}
 	applyVmLevelSettings(sd,
 		api.CriticalErrorAction_Pause, api.StartAction_Start, api.StopAction_Save,
-		true, 256, api.OnOffState_On, 64,
+		true, 256*1024*1024, api.OnOffState_On, 64*1024*1024,
 		"n1\nn2", `C:\new\paging`, "") // snapshot="" → 既存維持
 
 	if sd.InstanceID != "keep-me" {


### PR DESCRIPTION
## 問題

`api/hyperv-wsman/vm.go` の `applyVmLevelSettings`(CreateVm/UpdateVm共有)は `HighMmioGapSize`/`LowMmioGapSize` を byte単位のまま CIM に書き込んでいたが、`Msvm_VirtualSystemSettingData.HighMmioGapSize`/`LowMmioGapSize` は CIM上 **MB単位**(PR#103で読み取り側の`mbToBytesU64`変換を追加した際に確認済み)。

schema defaultの `low_memory_mapped_io_space`(128MB = 134217728byte)でもHyper-Vが `ErrorCode=32773`(無効な値)を返し、WS-Man経由の新規VM作成(CreateVm)が実機で必ず失敗していた。当初Issue起票時点では「configが非ゼロ値を明示しないため無害」と評価していたが、schema defaultが非ゼロのため実際には常に発火するバグだった。

homelab-infraの実terraform構成で新規VM作成テスト中に発見。

## 修正

`mbToBytesU64`(読み取り側)の逆変換 `bytesToMbU64` を追加し、`applyVmLevelSettings` の書き込み時に適用。

既存unit testはMB単位の値をそのまま渡す「golden偽陽性」になっており、実際の呼び出し元(byte単位)を反映していなかったため、byte単位の現実的な入力に修正(TDD: RED→GREEN確認済み)。round-trip unit testも追加。

## 検証

- unit test: `bytesToMbU64`/`mbToBytesU64` round-trip
- 実機: homelab-infra実構成でのWS-Man経由CreateVm(新規VM作成)が成功することを確認

Closes #105