### PR TITLE
fix: SecureBootTemplateId の差分なしガードを大文字小文字非依存に

### DIFF
--- a/api/hyperv-wsman/vm_firmware_write.go
+++ b/api/hyperv-wsman/vm_firmware_write.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"strings"
 
 	"github.com/r4sd/go-wsman/hyperv"
 	"github.com/taliesins/terraform-provider-hyperv/api"
@@ -67,9 +68,12 @@ func buildFirmwareCIMValues(
 // 前置なし+フォワードスラッシュ区切りの namespace) とで文字列表現が一致しない (Fable 指摘)。
 // 生文字列比較では常に不一致になり差分なしガードが機能しないため、両辺を
 // extractInstanceIDFromRef で素の InstanceID に正規化してから比較する。
+//
+// SecureBootTemplateId は GUID の大文字小文字表記がホストによって揺れうる
+// (go-wsman #103 の case-sensitivity 事故と同種、#100) ため EqualFold で比較する。
 func firmwareWriteNoop(current *hyperv.Msvm_VirtualSystemSettingData, want firmwareCIMValues) bool {
 	return current.SecureBoot == want.secureBoot &&
-		current.SecureBootTemplateId == want.secureBootTemplateGUID &&
+		strings.EqualFold(current.SecureBootTemplateId, want.secureBootTemplateGUID) &&
 		current.NetworkBootPreferredProtocol == want.networkBootProtocol &&
 		current.ConsoleMode == want.consoleMode &&
 		current.PauseAfterBootFailure == want.pauseAfterBootFailure &&

--- a/api/hyperv-wsman/vm_firmware_write_test.go
+++ b/api/hyperv-wsman/vm_firmware_write_test.go
@@ -2,6 +2,7 @@ package hyperv_wsman
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/r4sd/go-wsman/hyperv"
@@ -63,6 +64,34 @@ func TestFirmwareWriteNoop(t *testing.T) {
 	diff.consoleMode = hyperv.ConsoleModeCOM1
 	if firmwareWriteNoop(current, diff) {
 		t.Error("差分がある場合は no-op と判定されるべきではない")
+	}
+}
+
+// TestFirmwareWriteNoop_SecureBootTemplateIdCaseInsensitive は SecureBootTemplateId の GUID
+// 表記の大文字小文字がホストによって揺れても (go-wsman #103 の case-sensitivity 事故と同種)、
+// 同一テンプレートを指す限り no-op と判定されることを検証する (#100 既知ギャップ 2)。
+func TestFirmwareWriteNoop_SecureBootTemplateIdCaseInsensitive(t *testing.T) {
+	current := &hyperv.Msvm_VirtualSystemSettingData{
+		SecureBootTemplateId:         strings.ToLower(secureBootTemplateMicrosoftWindowsGUID),
+		NetworkBootPreferredProtocol: hyperv.NetworkBootPreferredProtocolIPv4,
+		ConsoleMode:                  hyperv.ConsoleModeDefault,
+	}
+	want := firmwareCIMValues{
+		secureBootTemplateGUID: secureBootTemplateMicrosoftWindowsGUID,
+		networkBootProtocol:    hyperv.NetworkBootPreferredProtocolIPv4,
+		consoleMode:            hyperv.ConsoleModeDefault,
+	}
+	if !firmwareWriteNoop(current, want) {
+		t.Error("大文字小文字表記が違うだけの同一 GUID は no-op と判定されるべき")
+	}
+
+	wantDifferentTemplate := firmwareCIMValues{
+		secureBootTemplateGUID: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+		networkBootProtocol:    hyperv.NetworkBootPreferredProtocolIPv4,
+		consoleMode:            hyperv.ConsoleModeDefault,
+	}
+	if firmwareWriteNoop(current, wantDifferentTemplate) {
+		t.Error("異なる GUID は no-op と判定されるべきではない")
 	}
 }
 


### PR DESCRIPTION
## 問題

`firmwareWriteNoop`(`api/hyperv-wsman/vm_firmware_write.go`)の`SecureBootTemplateId`比較が文字列完全一致のため、ホストによってGUIDの大文字小文字表記が揺れると(go-wsman #103のcase-sensitivity事故と同種)、実質同一テンプレートを指していても差分ありと誤判定し、無害だが不要な再書き込みが発生する経路があった。

## 修正

`strings.EqualFold`に変更。

## 検証

- unit test追加(`TestFirmwareWriteNoop_SecureBootTemplateIdCaseInsensitive`、TDD: RED→GREEN確認済み)
- `go build ./...` / `go vet ./...` / `go test ./... -count=1`: 全パス
- `gofmt -l`: 差分なし

## スコープ

#100(firmware write v2.1 既知ギャップ)の3件のうち2番目(大文字小文字比較)に対応。他2件(SecureBootTemplate GUID表がMicrosoftWindowsのみ収録/Driveのpath-only指定未対応)は実機での追加GUID確認・実装が必要なため本PRのスコープ外(#100はopenのまま残す)。