### PR TITLE
fix: 空の BootSourceOrder を「指定なし」として扱い Gen2 既定 create の PS 委譲を解消

### DIFF
--- a/api/hyperv-wsman/vm_firmware_write.go
+++ b/api/hyperv-wsman/vm_firmware_write.go
@@ -71,13 +71,21 @@ func buildFirmwareCIMValues(
 //
 // SecureBootTemplateId は GUID の大文字小文字表記がホストによって揺れうる
 // (go-wsman #103 の case-sensitivity 事故と同種、#100) ため EqualFold で比較する。
+//
+// BootSourceOrder の要求値が空の場合は「指定なし」として比較対象から外す (#99)。PS 版の
+// `Set-VMFirmware -BootOrder @()` が実機でエラーにならず既存値も変えない (= no-change) ことを
+// 確認済みで、空配列に「クリア」の意味は無い。config で vm_firmware を書かない Gen2 VM の
+// create では、NIC 追加で Hyper-V が自動登録した非空の現行値と既定の空要求値が並ぶため、
+// ここを差分と見なすと必ず PS へ委譲されていた。
 func firmwareWriteNoop(current *hyperv.Msvm_VirtualSystemSettingData, want firmwareCIMValues) bool {
+	bootOrderSame := len(want.bootSourceOrder) == 0 ||
+		stringSlicesEqual(normalizedBootSourceOrder(current.BootSourceOrder), normalizedBootSourceOrder(want.bootSourceOrder))
 	return current.SecureBoot == want.secureBoot &&
 		strings.EqualFold(current.SecureBootTemplateId, want.secureBootTemplateGUID) &&
 		current.NetworkBootPreferredProtocol == want.networkBootProtocol &&
 		current.ConsoleMode == want.consoleMode &&
 		current.PauseAfterBootFailure == want.pauseAfterBootFailure &&
-		stringSlicesEqual(normalizedBootSourceOrder(current.BootSourceOrder), normalizedBootSourceOrder(want.bootSourceOrder))
+		bootOrderSame
 }
 
 // normalizedBootSourceOrder は BootSourceOrder[] の各要素を素の InstanceID に正規化する
@@ -99,12 +107,14 @@ func normalizedBootSourceOrder(refs []string) []string {
 // 慣習) ため、この遷移は go-wsman では反映できず「成功報告なのに変わらない」恒常 diff になる
 // (Slice A vm_processor の Fable C パターンと同型)。NetworkBootPreferredProtocol は有効値が
 // 4096/4097 でどちらも非ゼロのため対象外 (常に表現可能)。
+//
+// BootSourceOrder は対象外 (#99)。PS 版が空配列を no-change として扱う以上、空の要求値は
+// 「クリア要求」ではなく「指定なし」であり、送らないこと自体が PS とのパリティになる。
 func firmwareZeroDowngrade(current *hyperv.Msvm_VirtualSystemSettingData, want firmwareCIMValues) bool {
 	return (current.SecureBoot && !want.secureBoot) ||
 		(current.PauseAfterBootFailure && !want.pauseAfterBootFailure) ||
 		(current.ConsoleMode != hyperv.ConsoleModeDefault && want.consoleMode == hyperv.ConsoleModeDefault) ||
-		(current.SecureBootTemplateId != "" && want.secureBootTemplateGUID == "") ||
-		(len(current.BootSourceOrder) > 0 && len(want.bootSourceOrder) == 0)
+		(current.SecureBootTemplateId != "" && want.secureBootTemplateGUID == "")
 }
 
 // applyFirmwareSettings は want を sd に反映する。sd は呼び出し側が InstanceID のみを設定した
@@ -116,7 +126,11 @@ func applyFirmwareSettings(sd *hyperv.Msvm_VirtualSystemSettingData, want firmwa
 	sd.NetworkBootPreferredProtocol = want.networkBootProtocol
 	sd.ConsoleMode = want.consoleMode
 	sd.PauseAfterBootFailure = want.pauseAfterBootFailure
-	sd.BootSourceOrder = want.bootSourceOrder
+	// 空の要求値は「指定なし」(#99) なので touch しない。marshalEmbeddedInstance が
+	// ゼロ値を送らない挙動に依存せず、意図として明示しておく。
+	if len(want.bootSourceOrder) > 0 {
+		sd.BootSourceOrder = want.bootSourceOrder
+	}
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/api/hyperv-wsman/vm_firmware_write_test.go
+++ b/api/hyperv-wsman/vm_firmware_write_test.go
@@ -129,6 +129,36 @@ func TestFirmwareWriteNoop_BootSourceOrderFormatMismatch(t *testing.T) {
 	}
 }
 
+// TestFirmwareWriteNoop_EmptyBootSourceOrderIsNoChange は「要求値の BootSourceOrder が空」の場合に
+// 現行値が非空でも差分なし (no-op) と判定されることを検証する (#99)。
+//
+// PS 版の実機挙動を確認したところ `Set-VMFirmware -BootOrder @()` はエラーにならず、既存の
+// BootSourceOrder も変化しない = 空配列は「クリア」ではなく「指定なし」として扱われる。
+// go-wsman 側もこれに合わせることで、vm_firmware 未指定の Gen2 create が PS 委譲されなくなる。
+func TestFirmwareWriteNoop_EmptyBootSourceOrderIsNoChange(t *testing.T) {
+	current := &hyperv.Msvm_VirtualSystemSettingData{
+		NetworkBootPreferredProtocol: hyperv.NetworkBootPreferredProtocolIPv4,
+		ConsoleMode:                  hyperv.ConsoleModeDefault,
+		// create 時に NIC が先に追加され Hyper-V が自動登録した状態を模す。
+		BootSourceOrder: []string{"ref-nic"},
+	}
+	want := firmwareCIMValues{
+		networkBootProtocol: hyperv.NetworkBootPreferredProtocolIPv4,
+		consoleMode:         hyperv.ConsoleModeDefault,
+		bootSourceOrder:     nil, // config で vm_firmware 未指定 = 既定値 (空)
+	}
+	if !firmwareWriteNoop(current, want) {
+		t.Error("要求値が空の BootSourceOrder は「指定なし」= 差分なしと判定されるべき (#99)")
+	}
+
+	// 非空同士は従来どおり比較する (指定があるなら差分を見る)。
+	wantDifferent := want
+	wantDifferent.bootSourceOrder = []string{"ref-other"}
+	if firmwareWriteNoop(current, wantDifferent) {
+		t.Error("非空で内容が異なる BootSourceOrder は差分ありと判定されるべき")
+	}
+}
+
 // TestFirmwareZeroDowngrade は marshalEmbeddedInstance がゼロ値を送信しないために go-wsman では
 // 表現できない「非ゼロ→ゼロ」遷移を正しく検出することを検証する (Slice A Fable C と同型のリスク)。
 func TestFirmwareZeroDowngrade(t *testing.T) {
@@ -175,10 +205,12 @@ func TestFirmwareZeroDowngrade(t *testing.T) {
 			wantDowngrade: true,
 		},
 		{
-			name:          "BootSourceOrder 非空→空 は非表現",
+			// #99: PS の `Set-VMFirmware -BootOrder @()` が no-change であることを実機で確認したため、
+			// 空の要求値は「クリア要求」ではなく「指定なし」。ダウングレード扱いしない。
+			name:          "BootSourceOrder 非空→空 は「指定なし」でダウングレードではない",
 			current:       &hyperv.Msvm_VirtualSystemSettingData{BootSourceOrder: []string{"ref-1"}},
 			want:          firmwareCIMValues{bootSourceOrder: nil},
-			wantDowngrade: true,
+			wantDowngrade: false,
 		},
 		{
 			name:          "全て変更なしはダウングレードではない",


### PR DESCRIPTION
## 問題

config で `vm_firmware` を指定しない Gen2 VM の create は、firmware write が**構造的に**PSへ委譲されていた。

create の実行順序では NIC/DVD/HDD が firmware より先に追加され、Hyper-V が自動で `BootSourceOrder` に登録する。そのため「現行値=非空 / 要求値=空(schema既定)」という組み合わせになり、`firmwareZeroDowngrade` の「非空→空は非表現」ルールに必ず当たっていた。

## 実機で確認した PS 版の挙動

`Set-VMFirmware -BootOrder @()` を Gen2 VM に対して実行:

```
BEFORE_COUNT=1
BEFORE_ITEM=Network | VMNetworkAdapter (Name = 'Network Adapter', VMName = 'tf-probe-99')
SET_RESULT=ok
AFTER_COUNT=1
AFTER_ITEM=Network | VMNetworkAdapter (Name = 'Network Adapter', VMName = 'tf-probe-99')
VERDICT=NO_CHANGE (空配列は無視され現状維持)
```

エラーにならず、既存の `BootSourceOrder` も変化しない。**空配列に「クリア」の意味は無く「指定なし」として扱われる**ことが確定した(Issue #99 の対応案でいう「後者」)。

## 修正

| 関数 | 変更 |
|---|---|
| `firmwareWriteNoop` | 要求値が空なら `BootSourceOrder` を比較対象から外す |
| `firmwareZeroDowngrade` | `BootSourceOrder` の分岐を削除(ダウングレードではない) |
| `applyFirmwareSettings` | 空の要求値では touch しない(`marshalEmbeddedInstance` のゼロ値スキップ挙動への暗黙依存をやめ、意図を明示) |

これにより **Gen2 既定構成の create が PS-0 を達成できる**。

## トレードオフ

`BootSourceOrder` を明示的に空へクリアする操作は表現できなくなる。ただし PS 版でも同じく表現できない(上記の実機結果)ため、シャドウ移行の目的であるパリティは保たれる。

## 検証

- unit test 追加(`TestFirmwareWriteNoop_EmptyBootSourceOrderIsNoChange`)、既存の `TestFirmwareZeroDowngrade` の該当ケースも新しい意味論に更新。TDD で RED→GREEN 確認済み
- `go build` / `go vet ./...` / `go test ./... -count=1`: 全パス
- `gofmt -l`: 変更ファイルはクリーン(`api/convert_test.go` の指摘は fork 由来の既存分で本 PR 対象外)

Closes #99